### PR TITLE
feat: scaffold Angular service-based frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,5 @@
 # front-fnanz
-Fnanz 
+
+Repositorio que contiene el frontend de Fnanz construido con Angular standalone orientado a servicios.
+
+Consulta la documentación específica dentro de `fnanz-app/README.md` para instrucciones de instalación y ejecución.

--- a/fnanz-app/.browserslistrc
+++ b/fnanz-app/.browserslistrc
@@ -1,0 +1,5 @@
+# Esta configuración es utilizada por autoprefixer, babel-preset-env y otros.
+> 0.5%
+last 2 versions
+Firefox ESR
+not dead

--- a/fnanz-app/.editorconfig
+++ b/fnanz-app/.editorconfig
@@ -1,0 +1,13 @@
+# Editor configuration, see https://editorconfig.org
+root = true
+
+[*]
+charset = utf-8
+indent_style = space
+indent_size = 2
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.md]
+max_line_length = off
+trim_trailing_whitespace = false

--- a/fnanz-app/.gitignore
+++ b/fnanz-app/.gitignore
@@ -1,0 +1,40 @@
+# See http://help.github.com/ignore-files/ for more about ignoring files.
+
+# compiled output
+/dist
+/tmp
+/out-tsc
+
+# dependencies
+/node_modules
+
+# profiling files
+chrome-profiler-events*.json
+speed-measure-plugin.json
+
+# IDEs and editors
+/.idea
+.project
+.classpath
+.c9/
+*.launch
+.settings/
+*.sublime-workspace
+
+# IDE - VSCode
+.vscode/*
+!.vscode/extensions.json
+
+# misc
+/.angular/cache
+.sass-cache
+/connect.lock
+/coverage
+/libpeerconnection.log
+npm-debug.log*
+yarn-error.log*
+lerna-debug.log*
+
+# System Files
+.DS_Store
+Thumbs.db

--- a/fnanz-app/README.md
+++ b/fnanz-app/README.md
@@ -1,0 +1,53 @@
+# Fnanz Angular Frontend
+
+Proyecto base en Angular standalone orientado a servicios para la plataforma Fnanz. La aplicación incluye una capa de servicios HTTP reutilizable y un módulo de ejemplo (dashboard) que consume datos desde dichos servicios.
+
+## Requisitos previos
+
+- Node.js 18 LTS o superior (recomendado Node 20)
+- npm 9+
+
+## Instalación
+
+```bash
+npm install
+```
+
+> **Nota:** En este entorno no fue posible descargar las dependencias de npm por políticas de red, pero el `package.json` queda listo para que ejecutes la instalación en tu máquina local.
+
+## Scripts disponibles
+
+- `npm run start`: levanta la aplicación en modo desarrollo (`http://localhost:4200`).
+- `npm run build`: genera un build optimizado para producción.
+- `npm run test`: ejecuta las pruebas unitarias con Karma + Jasmine.
+
+## Configuración de entornos
+
+La URL base del backend se define en `src/environments`:
+
+- `environment.development.ts`: usado al ejecutar `ng serve` (modo desarrollo).
+- `environment.ts`: usado en el build de producción.
+
+Ajusta la propiedad `apiBaseUrl` con la URL real de tus servicios.
+
+## Próximos pasos
+
+1. Conectar los servicios reales usando los contratos Swagger que compartirás.
+2. Reemplazar la respuesta mock del `DashboardService` por llamadas a los endpoints reales.
+3. Añadir nuevas pantallas reutilizando la capa de servicios (`ApiHttpService`).
+
+## Estructura relevante
+
+```
+src/
+├── app/
+│   ├── app.component.*        # Shell principal
+│   ├── app.config.ts          # Configuración global de providers
+│   ├── app.routes.ts          # Ruteo principal
+│   ├── core/
+│   │   └── services/          # Servicios compartidos (HTTP, environment, etc.)
+│   ├── features/
+│   │   └── dashboard/         # Ejemplo de pantalla basada en servicios
+│   └── shared/                # Modelos y utilidades compartidas
+└── environments/              # Configuración de entornos
+```

--- a/fnanz-app/angular.json
+++ b/fnanz-app/angular.json
@@ -1,0 +1,103 @@
+{
+  "$schema": "./node_modules/@angular/cli/lib/config/schema.json",
+  "version": 1,
+  "newProjectRoot": "projects",
+  "projects": {
+    "fnanz-app": {
+      "projectType": "application",
+      "schematics": {},
+      "root": "",
+      "sourceRoot": "src",
+      "prefix": "app",
+      "architect": {
+        "build": {
+          "builder": "@angular-devkit/build-angular:browser",
+          "options": {
+            "outputPath": "dist/fnanz-app",
+            "index": "src/index.html",
+            "main": "src/main.ts",
+            "polyfills": ["zone.js"],
+            "tsConfig": "tsconfig.app.json",
+            "inlineStyleLanguage": "scss",
+            "assets": [
+              "src/favicon.ico",
+              "src/assets"
+            ],
+            "styles": [
+              "src/styles.scss"
+            ],
+            "scripts": []
+          },
+          "configurations": {
+            "production": {
+              "budgets": [
+                {
+                  "type": "initial",
+                  "maximumWarning": "500kb",
+                  "maximumError": "1mb"
+                },
+                {
+                  "type": "anyComponentStyle",
+                  "maximumWarning": "2kb",
+                  "maximumError": "4kb"
+                }
+              ],
+              "outputHashing": "all"
+            },
+            "development": {
+              "buildOptimizer": false,
+              "optimization": false,
+              "vendorChunk": true,
+              "extractLicenses": false,
+              "sourceMap": true,
+              "namedChunks": true,
+              "fileReplacements": [
+                {
+                  "replace": "src/environments/environment.ts",
+                  "with": "src/environments/environment.development.ts"
+                }
+              ]
+            }
+          },
+          "defaultConfiguration": "production"
+        },
+        "serve": {
+          "builder": "@angular-devkit/build-angular:dev-server",
+          "configurations": {
+            "production": {
+              "browserTarget": "fnanz-app:build:production"
+            },
+            "development": {
+              "browserTarget": "fnanz-app:build:development"
+            }
+          },
+          "defaultConfiguration": "development"
+        },
+        "extract-i18n": {
+          "builder": "@angular-devkit/build-angular:extract-i18n",
+          "options": {
+            "browserTarget": "fnanz-app:build"
+          }
+        },
+        "test": {
+          "builder": "@angular-devkit/build-angular:karma",
+          "options": {
+            "polyfills": ["zone.js", "zone.js/testing"],
+            "tsConfig": "tsconfig.spec.json",
+            "assets": [
+              "src/favicon.ico",
+              "src/assets"
+            ],
+            "styles": [
+              "src/styles.scss"
+            ],
+            "scripts": []
+          }
+        }
+      }
+    }
+  },
+  "cli": {
+    "analytics": false
+  }
+}

--- a/fnanz-app/karma.conf.js
+++ b/fnanz-app/karma.conf.js
@@ -1,0 +1,39 @@
+const { join } = require('path');
+const { constants } = require('karma');
+
+module.exports = function (config) {
+  config.set({
+    basePath: '',
+    frameworks: ['jasmine', '@angular-devkit/build-angular'],
+    plugins: [
+      require('karma-jasmine'),
+      require('karma-chrome-launcher'),
+      require('karma-jasmine-html-reporter'),
+      require('karma-coverage'),
+      require('@angular-devkit/build-angular/plugins/karma')
+    ],
+    client: {
+      jasmine: {},
+      clearContext: false
+    },
+    jasmineHtmlReporter: {
+      suppressAll: true
+    },
+    coverageReporter: {
+      dir: join(__dirname, './coverage/fnanz-app'),
+      subdir: '.',
+      reporters: [
+        { type: 'html' },
+        { type: 'text-summary' }
+      ]
+    },
+    reporters: ['progress', 'kjhtml'],
+    port: 9876,
+    colors: true,
+    logLevel: constants.LOG_INFO,
+    autoWatch: true,
+    browsers: ['Chrome'],
+    singleRun: false,
+    restartOnFileChange: true
+  });
+};

--- a/fnanz-app/package.json
+++ b/fnanz-app/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "fnanz-app",
+  "version": "0.0.1",
+  "private": true,
+  "scripts": {
+    "ng": "ng",
+    "start": "ng serve",
+    "build": "ng build",
+    "watch": "ng build --watch --configuration development",
+    "test": "ng test"
+  },
+  "dependencies": {
+    "@angular/animations": "^17.3.8",
+    "@angular/common": "^17.3.8",
+    "@angular/compiler": "^17.3.8",
+    "@angular/core": "^17.3.8",
+    "@angular/forms": "^17.3.8",
+    "@angular/localize": "^17.3.8",
+    "@angular/platform-browser": "^17.3.8",
+    "@angular/platform-browser-dynamic": "^17.3.8",
+    "@angular/router": "^17.3.8",
+    "rxjs": "~7.8.1",
+    "tslib": "^2.6.2",
+    "zone.js": "~0.14.5"
+  },
+  "devDependencies": {
+    "@angular-devkit/build-angular": "^17.3.8",
+    "@angular/cli": "^17.3.8",
+    "@angular/compiler-cli": "^17.3.8",
+    "@types/jasmine": "~5.1.4",
+    "jasmine-core": "~5.1.1",
+    "karma": "~6.4.3",
+    "karma-chrome-launcher": "~3.2.0",
+    "karma-coverage": "~2.2.0",
+    "karma-jasmine": "~5.1.0",
+    "karma-jasmine-html-reporter": "~2.1.0",
+    "typescript": "~5.3.3"
+  }
+}

--- a/fnanz-app/src/app/app.component.html
+++ b/fnanz-app/src/app/app.component.html
@@ -1,0 +1,14 @@
+<header class="app-header">
+  <div class="container">
+    <h1>Fnanz Plataforma</h1>
+    <span class="env-pill">{{ envLabel() }}</span>
+  </div>
+</header>
+<main class="container">
+  <router-outlet />
+</main>
+<footer class="app-footer">
+  <div class="container">
+    <p>&copy; {{ new Date().getFullYear() }} Fnanz. Construido con Angular standalone y servicios.</p>
+  </div>
+</footer>

--- a/fnanz-app/src/app/app.component.html
+++ b/fnanz-app/src/app/app.component.html
@@ -9,6 +9,6 @@
 </main>
 <footer class="app-footer">
   <div class="container">
-    <p>&copy; {{ new Date().getFullYear() }} Fnanz. Construido con Angular standalone y servicios.</p>
+    <p>&copy; {{ currentYear }} Fnanz. Construido con Angular standalone y servicios.</p>
   </div>
 </footer>

--- a/fnanz-app/src/app/app.component.scss
+++ b/fnanz-app/src/app/app.component.scss
@@ -1,0 +1,26 @@
+.app-header,
+.app-footer {
+  background: linear-gradient(90deg, var(--fnanz-primary), var(--fnanz-secondary));
+  color: #fff;
+  padding: 1rem 0;
+}
+
+.app-header h1 {
+  margin: 0;
+  font-weight: 600;
+}
+
+.env-pill {
+  background-color: rgba(255, 255, 255, 0.15);
+  border-radius: 9999px;
+  padding: 0.25rem 0.75rem;
+  font-size: 0.875rem;
+}
+
+main {
+  padding: 2rem 0;
+}
+
+.app-footer {
+  font-size: 0.875rem;
+}

--- a/fnanz-app/src/app/app.component.spec.ts
+++ b/fnanz-app/src/app/app.component.spec.ts
@@ -1,0 +1,20 @@
+import { TestBed } from '@angular/core/testing';
+import { provideRouter } from '@angular/router';
+
+import { AppComponent } from './app.component';
+import { routes } from './app.routes';
+
+describe('AppComponent', () => {
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [AppComponent],
+      providers: [provideRouter(routes)]
+    }).compileComponents();
+  });
+
+  it('should create the app', () => {
+    const fixture = TestBed.createComponent(AppComponent);
+    const app = fixture.componentInstance;
+    expect(app).toBeTruthy();
+  });
+});

--- a/fnanz-app/src/app/app.component.ts
+++ b/fnanz-app/src/app/app.component.ts
@@ -14,4 +14,5 @@ export class AppComponent {
   private readonly environmentService = inject(EnvironmentService);
 
   readonly envLabel = signal(this.environmentService.environmentLabel);
+  readonly currentYear = new Date().getFullYear();
 }

--- a/fnanz-app/src/app/app.component.ts
+++ b/fnanz-app/src/app/app.component.ts
@@ -1,0 +1,17 @@
+import { Component, inject, signal } from '@angular/core';
+import { RouterOutlet } from '@angular/router';
+
+import { EnvironmentService } from './core/services/environment.service';
+
+@Component({
+  selector: 'app-root',
+  standalone: true,
+  imports: [RouterOutlet],
+  templateUrl: './app.component.html',
+  styleUrls: ['./app.component.scss']
+})
+export class AppComponent {
+  private readonly environmentService = inject(EnvironmentService);
+
+  readonly envLabel = signal(this.environmentService.environmentLabel);
+}

--- a/fnanz-app/src/app/app.config.ts
+++ b/fnanz-app/src/app/app.config.ts
@@ -1,0 +1,13 @@
+import { ApplicationConfig, provideZoneChangeDetection } from '@angular/core';
+import { provideRouter, withComponentInputBinding } from '@angular/router';
+import { provideHttpClient, withInterceptorsFromDi } from '@angular/common/http';
+
+import { routes } from './app.routes';
+
+export const appConfig: ApplicationConfig = {
+  providers: [
+    provideZoneChangeDetection({ eventCoalescing: true }),
+    provideRouter(routes, withComponentInputBinding()),
+    provideHttpClient(withInterceptorsFromDi())
+  ]
+};

--- a/fnanz-app/src/app/app.routes.ts
+++ b/fnanz-app/src/app/app.routes.ts
@@ -1,0 +1,15 @@
+import { Routes } from '@angular/router';
+
+import { DashboardComponent } from './features/dashboard/dashboard.component';
+
+export const routes: Routes = [
+  {
+    path: '',
+    pathMatch: 'full',
+    component: DashboardComponent
+  },
+  {
+    path: '**',
+    redirectTo: ''
+  }
+];

--- a/fnanz-app/src/app/core/services/api-http.service.spec.ts
+++ b/fnanz-app/src/app/core/services/api-http.service.spec.ts
@@ -1,0 +1,32 @@
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { TestBed } from '@angular/core/testing';
+
+import { ApiHttpService } from './api-http.service';
+import { EnvironmentService } from './environment.service';
+
+describe('ApiHttpService', () => {
+  let service: ApiHttpService;
+  let httpMock: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+      providers: [ApiHttpService, EnvironmentService]
+    });
+
+    service = TestBed.inject(ApiHttpService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+  });
+
+  it('should perform GET requests with the environment base URL', () => {
+    service.get('health').subscribe();
+
+    const request = httpMock.expectOne('https://api.fnanz.local/health');
+    expect(request.request.method).toBe('GET');
+    request.flush({});
+  });
+});

--- a/fnanz-app/src/app/core/services/api-http.service.ts
+++ b/fnanz-app/src/app/core/services/api-http.service.ts
@@ -1,0 +1,38 @@
+import { HttpClient } from '@angular/common/http';
+import { inject, Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+
+import { EnvironmentService } from './environment.service';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class ApiHttpService {
+  private readonly http = inject(HttpClient);
+  private readonly environment = inject(EnvironmentService);
+
+  private buildUrl(endpoint: string): string {
+    const normalized = endpoint.startsWith('/') ? endpoint.slice(1) : endpoint;
+    return `${this.environment.apiBaseUrl}/${normalized}`;
+  }
+
+  get<T>(endpoint: string, options?: object): Observable<T> {
+    return this.http.get<T>(this.buildUrl(endpoint), options);
+  }
+
+  post<T>(endpoint: string, body: unknown, options?: object): Observable<T> {
+    return this.http.post<T>(this.buildUrl(endpoint), body, options);
+  }
+
+  put<T>(endpoint: string, body: unknown, options?: object): Observable<T> {
+    return this.http.put<T>(this.buildUrl(endpoint), body, options);
+  }
+
+  patch<T>(endpoint: string, body: unknown, options?: object): Observable<T> {
+    return this.http.patch<T>(this.buildUrl(endpoint), body, options);
+  }
+
+  delete<T>(endpoint: string, options?: object): Observable<T> {
+    return this.http.delete<T>(this.buildUrl(endpoint), options);
+  }
+}

--- a/fnanz-app/src/app/core/services/environment.service.spec.ts
+++ b/fnanz-app/src/app/core/services/environment.service.spec.ts
@@ -1,0 +1,10 @@
+import { environment } from '../../../environments/environment';
+import { EnvironmentService } from './environment.service';
+
+describe('EnvironmentService', () => {
+  it('should expose apiBaseUrl and environmentLabel', () => {
+    const service = new EnvironmentService();
+    expect(service.apiBaseUrl).toBe(environment.apiBaseUrl);
+    expect(service.environmentLabel).toBe('Producción');
+  });
+});

--- a/fnanz-app/src/app/core/services/environment.service.ts
+++ b/fnanz-app/src/app/core/services/environment.service.ts
@@ -1,0 +1,11 @@
+import { Injectable } from '@angular/core';
+
+import { environment } from '../../../environments/environment';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class EnvironmentService {
+  readonly apiBaseUrl = environment.apiBaseUrl;
+  readonly environmentLabel = environment.production ? 'Producción' : 'Desarrollo';
+}

--- a/fnanz-app/src/app/features/dashboard/dashboard.component.html
+++ b/fnanz-app/src/app/features/dashboard/dashboard.component.html
@@ -1,0 +1,30 @@
+<section class="card">
+  <header class="card__header">
+    <div>
+      <h2>Estado de microservicios</h2>
+      <p class="card__subtitle">Última actualización: {{ lastRefresh() | date: 'short' }}</p>
+    </div>
+    <button type="button" class="refresh-button" (click)="refresh()">
+      Actualizar
+    </button>
+  </header>
+
+  <ng-container *ngIf="healthSnapshot$ | async as snapshot; else loading">
+    <div class="service-grid">
+      <article class="service" *ngFor="let service of snapshot">
+        <header class="service__header">
+          <h3>{{ service.name }}</h3>
+          <span [ngClass]="resolveStatusClass(service.status)">
+            {{ service.status }}
+          </span>
+        </header>
+        <p class="service__meta">Último chequeo: {{ service.lastCheckedAt | date: 'medium' }}</p>
+        <p class="service__notes" *ngIf="service.notes as notes">{{ notes }}</p>
+      </article>
+    </div>
+  </ng-container>
+
+  <ng-template #loading>
+    <p class="loading">Cargando estado del sistema...</p>
+  </ng-template>
+</section>

--- a/fnanz-app/src/app/features/dashboard/dashboard.component.scss
+++ b/fnanz-app/src/app/features/dashboard/dashboard.component.scss
@@ -1,0 +1,97 @@
+.card__header {
+  align-items: center;
+  display: flex;
+  gap: 1rem;
+  justify-content: space-between;
+  margin-bottom: 1.5rem;
+}
+
+.card__subtitle {
+  color: rgba(31, 41, 55, 0.7);
+  margin: 0.25rem 0 0;
+}
+
+.refresh-button {
+  background: linear-gradient(90deg, var(--fnanz-primary), var(--fnanz-secondary));
+  border: none;
+  border-radius: 9999px;
+  color: #fff;
+  cursor: pointer;
+  font-weight: 600;
+  padding: 0.6rem 1.5rem;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+.refresh-button:hover {
+  box-shadow: 0 12px 24px rgba(0, 45, 110, 0.2);
+  transform: translateY(-1px);
+}
+
+.service-grid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+}
+
+.service {
+  border: 1px solid rgba(0, 80, 179, 0.08);
+  border-radius: 0.75rem;
+  padding: 1rem;
+  background: #fff;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.service__header {
+  align-items: center;
+  display: flex;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+
+.service__header h3 {
+  font-size: 1.05rem;
+  margin: 0;
+}
+
+.service__meta {
+  color: rgba(31, 41, 55, 0.65);
+  font-size: 0.85rem;
+  margin: 0;
+}
+
+.service__notes {
+  color: rgba(31, 41, 55, 0.85);
+  font-size: 0.9rem;
+  margin: 0;
+}
+
+.status-pill {
+  border-radius: 9999px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  padding: 0.25rem 0.75rem;
+  text-transform: uppercase;
+}
+
+.status-pill--up {
+  background: rgba(16, 185, 129, 0.15);
+  color: #047857;
+}
+
+.status-pill--degraded {
+  background: rgba(234, 179, 8, 0.2);
+  color: #92400e;
+}
+
+.status-pill--down {
+  background: rgba(239, 68, 68, 0.2);
+  color: #b91c1c;
+}
+
+.loading {
+  color: rgba(31, 41, 55, 0.75);
+  margin: 2rem 0 0;
+  text-align: center;
+}

--- a/fnanz-app/src/app/features/dashboard/dashboard.component.spec.ts
+++ b/fnanz-app/src/app/features/dashboard/dashboard.component.spec.ts
@@ -1,0 +1,33 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { of } from 'rxjs';
+
+import { DashboardComponent } from './dashboard.component';
+import { DashboardService } from './dashboard.service';
+
+class DashboardServiceStub {
+  loadSystemHealth() {
+    return of([]);
+  }
+
+  refresh(): void {
+    // noop
+  }
+}
+
+describe('DashboardComponent', () => {
+  let fixture: ComponentFixture<DashboardComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [DashboardComponent],
+      providers: [{ provide: DashboardService, useClass: DashboardServiceStub }]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(DashboardComponent);
+    fixture.detectChanges();
+  });
+
+  it('should create the component', () => {
+    expect(fixture.componentInstance).toBeTruthy();
+  });
+});

--- a/fnanz-app/src/app/features/dashboard/dashboard.component.ts
+++ b/fnanz-app/src/app/features/dashboard/dashboard.component.ts
@@ -1,0 +1,35 @@
+import { AsyncPipe, DatePipe, NgClass, NgFor, NgIf } from '@angular/common';
+import { Component, inject, signal } from '@angular/core';
+
+import { SystemHealth } from '../../shared/models/system-health.model';
+import { DashboardService } from './dashboard.service';
+
+@Component({
+  selector: 'app-dashboard',
+  standalone: true,
+  imports: [AsyncPipe, DatePipe, NgClass, NgFor, NgIf],
+  templateUrl: './dashboard.component.html',
+  styleUrls: ['./dashboard.component.scss']
+})
+export class DashboardComponent {
+  private readonly dashboardService = inject(DashboardService);
+
+  readonly lastRefresh = signal(new Date());
+  readonly healthSnapshot$ = this.dashboardService.loadSystemHealth();
+
+  refresh(): void {
+    this.dashboardService.refresh();
+    this.lastRefresh.set(new Date());
+  }
+
+  resolveStatusClass(status: SystemHealth['status']): string {
+    switch (status) {
+      case 'UP':
+        return 'status-pill status-pill--up';
+      case 'DEGRADED':
+        return 'status-pill status-pill--degraded';
+      default:
+        return 'status-pill status-pill--down';
+    }
+  }
+}

--- a/fnanz-app/src/app/features/dashboard/dashboard.service.spec.ts
+++ b/fnanz-app/src/app/features/dashboard/dashboard.service.spec.ts
@@ -1,0 +1,48 @@
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { TestBed } from '@angular/core/testing';
+
+import { DashboardService } from './dashboard.service';
+import { EnvironmentService } from '../../core/services/environment.service';
+
+const environmentMock = {
+  apiBaseUrl: 'http://localhost:3000/api',
+  environmentLabel: 'Desarrollo'
+};
+
+describe('DashboardService', () => {
+  let service: DashboardService;
+  let httpMock: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+      providers: [
+        DashboardService,
+        {
+          provide: EnvironmentService,
+          useValue: {
+            apiBaseUrl: environmentMock.apiBaseUrl,
+            environmentLabel: environmentMock.environmentLabel
+          }
+        }
+      ]
+    });
+
+    service = TestBed.inject(DashboardService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+  });
+
+  it('should call the system health endpoint when refreshing', () => {
+    const expected = `${environmentMock.apiBaseUrl}/system/health`;
+
+    service.refresh();
+    service.loadSystemHealth().subscribe();
+
+    const request = httpMock.expectOne(expected);
+    request.flush([]);
+  });
+});

--- a/fnanz-app/src/app/features/dashboard/dashboard.service.ts
+++ b/fnanz-app/src/app/features/dashboard/dashboard.service.ts
@@ -1,0 +1,55 @@
+import { inject, Injectable } from '@angular/core';
+import { BehaviorSubject, catchError, map, Observable, of, switchMap } from 'rxjs';
+
+import { ApiHttpService } from '../../core/services/api-http.service';
+import { SystemHealth } from '../../shared/models/system-health.model';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class DashboardService {
+  private readonly api = inject(ApiHttpService);
+  private readonly refreshTrigger$ = new BehaviorSubject<void>(undefined);
+
+  loadSystemHealth(): Observable<SystemHealth[]> {
+    return this.refreshTrigger$.pipe(
+      switchMap(() =>
+        this.api.get<SystemHealth[]>('system/health').pipe(
+          map((response) => (response && response.length ? response : this.buildMockResponse())),
+          catchError((error) => {
+            console.error('Error al cargar el estado del sistema', error);
+            return of(this.buildMockResponse());
+          })
+        )
+      )
+    );
+  }
+
+  refresh(): void {
+    this.refreshTrigger$.next();
+  }
+
+  private buildMockResponse(): SystemHealth[] {
+    const now = new Date().toISOString();
+    return [
+      {
+        name: 'Core Identity',
+        status: 'UP',
+        lastCheckedAt: now,
+        notes: 'Servicio funcionando correctamente.'
+      },
+      {
+        name: 'Pagos',
+        status: 'DEGRADED',
+        lastCheckedAt: now,
+        notes: 'Latencia superior a lo esperado, investigando con el equipo DevOps.'
+      },
+      {
+        name: 'Notificaciones',
+        status: 'DOWN',
+        lastCheckedAt: now,
+        notes: 'Dependencia externa sin respuesta. Reintentando cada 60 segundos.'
+      }
+    ];
+  }
+}

--- a/fnanz-app/src/app/shared/models/system-health.model.ts
+++ b/fnanz-app/src/app/shared/models/system-health.model.ts
@@ -1,0 +1,6 @@
+export interface SystemHealth {
+  name: string;
+  status: 'UP' | 'DOWN' | 'DEGRADED';
+  lastCheckedAt: string;
+  notes?: string;
+}

--- a/fnanz-app/src/environments/environment.development.ts
+++ b/fnanz-app/src/environments/environment.development.ts
@@ -1,0 +1,4 @@
+export const environment = {
+  production: false,
+  apiBaseUrl: 'http://localhost:3000/api'
+};

--- a/fnanz-app/src/environments/environment.ts
+++ b/fnanz-app/src/environments/environment.ts
@@ -1,0 +1,4 @@
+export const environment = {
+  production: true,
+  apiBaseUrl: 'https://api.fnanz.local'
+};

--- a/fnanz-app/src/index.html
+++ b/fnanz-app/src/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="es">
+  <head>
+    <meta charset="utf-8" />
+    <title>Fnanz App</title>
+    <base href="/" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link rel="icon" type="image/x-icon" href="favicon.ico" />
+  </head>
+  <body>
+    <app-root></app-root>
+  </body>
+</html>

--- a/fnanz-app/src/main.ts
+++ b/fnanz-app/src/main.ts
@@ -1,0 +1,8 @@
+import { bootstrapApplication } from '@angular/platform-browser';
+
+import { AppComponent } from './app/app.component';
+import { appConfig } from './app/app.config';
+
+bootstrapApplication(AppComponent, appConfig).catch((err) =>
+  console.error('Bootstrap error', err)
+);

--- a/fnanz-app/src/styles.scss
+++ b/fnanz-app/src/styles.scss
@@ -1,0 +1,39 @@
+@use 'sass:color';
+
+:root {
+  --fnanz-primary: #0050b3;
+  --fnanz-secondary: #1890ff;
+  --fnanz-background: #f5f9ff;
+  --fnanz-surface: #ffffff;
+  --fnanz-text: #1f2937;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif;
+  background-color: var(--fnanz-background);
+  color: var(--fnanz-text);
+  min-height: 100vh;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+.container {
+  margin: 0 auto;
+  max-width: 960px;
+  padding: 1.5rem;
+}
+
+.card {
+  background: var(--fnanz-surface);
+  border-radius: 1rem;
+  box-shadow: 0 10px 30px rgba(0, 40, 90, 0.08);
+  padding: 1.5rem;
+}

--- a/fnanz-app/src/test.ts
+++ b/fnanz-app/src/test.ts
@@ -1,0 +1,10 @@
+import '@angular/localize/init';
+import 'zone.js/testing';
+
+import { getTestBed } from '@angular/core/testing';
+import {
+  BrowserDynamicTestingModule,
+  platformBrowserDynamicTesting
+} from '@angular/platform-browser-dynamic/testing';
+
+getTestBed().initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting());

--- a/fnanz-app/tsconfig.app.json
+++ b/fnanz-app/tsconfig.app.json
@@ -1,0 +1,13 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./out-tsc/app",
+    "types": []
+  },
+  "files": [
+    "src/main.ts"
+  ],
+  "include": [
+    "src/**/*.d.ts"
+  ]
+}

--- a/fnanz-app/tsconfig.json
+++ b/fnanz-app/tsconfig.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "display": "Angular",
+  "compilerOptions": {
+    "outDir": "./out-tsc",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "sourceMap": true,
+    "declaration": false,
+    "emitDecoratorMetadata": true,
+    "experimentalDecorators": true,
+    "moduleResolution": "node",
+    "importHelpers": true,
+    "target": "es2022",
+    "module": "es2022",
+    "useDefineForClassFields": false,
+    "lib": [
+      "es2022",
+      "dom"
+    ]
+  },
+  "angularCompilerOptions": {
+    "enableI18nLegacyMessageIdFormat": false,
+    "strictInjectionParameters": true,
+    "strictInputAccessModifiers": true,
+    "strictTemplates": true
+  }
+}

--- a/fnanz-app/tsconfig.spec.json
+++ b/fnanz-app/tsconfig.spec.json
@@ -1,0 +1,16 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./out-tsc/spec",
+    "types": [
+      "jasmine"
+    ]
+  },
+  "files": [
+    "src/test.ts"
+  ],
+  "include": [
+    "src/**/*.spec.ts",
+    "src/**/*.d.ts"
+  ]
+}


### PR DESCRIPTION
## Summary
- scaffold an Angular standalone workspace configured with routing, tooling, and environment separation
- add shared ApiHttpService and EnvironmentService to centralize HTTP consumption and expose environment metadata
- implement a dashboard feature that consumes the service layer with mock fallback data and document how to run the project locally

## Testing
- npm install *(fails: registry access returns 403 in container)*

------
https://chatgpt.com/codex/tasks/task_e_68daa183a1dc832f80474e8548a4376a