### PR TITLE
feat: add gastos reservados crud

### DIFF
--- a/fnanz-app/src/app/app.component.html
+++ b/fnanz-app/src/app/app.component.html
@@ -7,6 +7,7 @@
     <nav class="app-nav">
       <a routerLink="/" routerLinkActive="active-link" [routerLinkActiveOptions]="{ exact: true }">Dashboard</a>
       <a routerLink="/categorias-financieras" routerLinkActive="active-link">Categorías financieras</a>
+      <a routerLink="/gastos-reservados" routerLinkActive="active-link">Gastos reservados</a>
     </nav>
   </div>
 </header>

--- a/fnanz-app/src/app/app.component.html
+++ b/fnanz-app/src/app/app.component.html
@@ -1,21 +1,61 @@
-<header class="app-header">
-  <div class="container app-header__content">
-    <div class="app-header__brand">
-      <h1>Fnanz Plataforma</h1>
-      <span class="env-pill">{{ envLabel() }}</span>
+<div class="app-layout">
+  <aside class="app-sidebar">
+    <div class="app-sidebar__brand">
+      <div class="app-logo" aria-hidden="true">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+          <path d="M4 19v-6m5 6V5m5 14v-9m5 9V9" />
+          <path d="M3 21h18" />
+        </svg>
+      </div>
+      <div class="app-brand-text">
+        <h1>Fnanz Plataforma</h1>
+        <span class="env-pill">{{ envLabel() }}</span>
+      </div>
     </div>
-    <nav class="app-nav">
-      <a routerLink="/" routerLinkActive="active-link" [routerLinkActiveOptions]="{ exact: true }">Dashboard</a>
-      <a routerLink="/categorias-financieras" routerLinkActive="active-link">Categorías financieras</a>
-      <a routerLink="/gastos-reservados" routerLinkActive="active-link">Gastos reservados</a>
+    <nav class="app-sidebar__nav">
+      <a routerLink="/" routerLinkActive="active-link" [routerLinkActiveOptions]="{ exact: true }">
+        <span class="nav-icon" aria-hidden="true">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M3 11l9-8 9 8" />
+            <path d="M5 13v7h4v-4h6v4h4v-7" />
+          </svg>
+        </span>
+        <span>Dashboard</span>
+      </a>
+      <a routerLink="/categorias-financieras" routerLinkActive="active-link">
+        <span class="nav-icon" aria-hidden="true">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M4 4h6v6H4zM14 4h6v6h-6zM4 14h6v6H4zM14 14h6v6h-6z" />
+          </svg>
+        </span>
+        <span>Categorías financieras</span>
+      </a>
+      <a routerLink="/gastos-reservados" routerLinkActive="active-link">
+        <span class="nav-icon" aria-hidden="true">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M12 1v4" />
+            <path d="M7 5h10l4 6-4 6H7L3 11z" />
+            <path d="M12 9v4" />
+            <path d="M10 13h4" />
+          </svg>
+        </span>
+        <span>Gastos reservados</span>
+      </a>
     </nav>
+  </aside>
+  <div class="app-main">
+    <header class="app-header">
+      <h2>Panel administrativo</h2>
+    </header>
+    <main class="app-main__content">
+      <div class="container">
+        <router-outlet />
+      </div>
+    </main>
+    <footer class="app-footer">
+      <div class="container">
+        <p>&copy; {{ currentYear }} Fnanz. Construido con Angular standalone y servicios.</p>
+      </div>
+    </footer>
   </div>
-</header>
-<main class="container">
-  <router-outlet />
-</main>
-<footer class="app-footer">
-  <div class="container">
-    <p>&copy; {{ currentYear }} Fnanz. Construido con Angular standalone y servicios.</p>
-  </div>
-</footer>
+</div>

--- a/fnanz-app/src/app/app.component.scss
+++ b/fnanz-app/src/app/app.component.scss
@@ -1,61 +1,170 @@
-.app-header,
-.app-footer {
-  background: linear-gradient(90deg, var(--fnanz-primary), var(--fnanz-secondary));
+.app-layout {
+  display: flex;
+  min-height: 100vh;
+  background: linear-gradient(180deg, rgba(24, 144, 255, 0.1), rgba(0, 80, 179, 0.08));
+}
+
+.app-sidebar {
+  background: linear-gradient(180deg, var(--fnanz-primary), var(--fnanz-secondary));
   color: #fff;
-  padding: 1rem 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+  padding: 2rem 1.5rem;
+  width: 280px;
 }
 
-.app-header__content {
+.app-sidebar__brand {
   align-items: center;
   display: flex;
-  gap: 1.5rem;
-  justify-content: space-between;
-  flex-wrap: wrap;
+  gap: 1rem;
 }
 
-.app-header__brand {
-  display: flex;
+.app-logo {
   align-items: center;
-  gap: 0.75rem;
+  background: rgba(255, 255, 255, 0.12);
+  border-radius: 1rem;
+  display: inline-flex;
+  height: 3rem;
+  justify-content: center;
+  width: 3rem;
 }
 
-.app-header h1 {
-  margin: 0;
+.app-logo svg {
+  height: 1.75rem;
+  width: 1.75rem;
+}
+
+.app-brand-text h1 {
+  font-size: 1.25rem;
   font-weight: 600;
+  margin: 0 0 0.35rem;
 }
 
 .env-pill {
   background-color: rgba(255, 255, 255, 0.15);
   border-radius: 9999px;
-  padding: 0.25rem 0.75rem;
-  font-size: 0.875rem;
+  font-size: 0.75rem;
+  padding: 0.25rem 0.85rem;
 }
 
-.app-nav {
+.app-sidebar__nav {
   display: flex;
-  gap: 1rem;
+  flex-direction: column;
+  gap: 0.5rem;
 }
 
-.app-nav a {
-  border-radius: 999px;
-  padding: 0.4rem 1rem;
-  transition: background-color 0.2s ease, color 0.2s ease;
+.app-sidebar__nav a {
+  align-items: center;
+  border-radius: 0.75rem;
+  color: inherit;
+  display: flex;
   font-weight: 500;
+  gap: 0.75rem;
+  padding: 0.75rem 1rem;
+  transition: background-color 0.2s ease, transform 0.2s ease;
 }
 
-.app-nav a:hover {
+.app-sidebar__nav a:hover {
   background-color: rgba(255, 255, 255, 0.2);
+  transform: translateX(4px);
 }
 
-.app-nav .active-link {
+.app-sidebar__nav .active-link {
   background-color: #fff;
   color: var(--fnanz-primary);
+  box-shadow: 0 10px 20px rgba(0, 0, 0, 0.15);
 }
 
-main {
+.nav-icon {
+  align-items: center;
+  background-color: rgba(255, 255, 255, 0.2);
+  border-radius: 0.75rem;
+  display: inline-flex;
+  height: 2.25rem;
+  justify-content: center;
+  width: 2.25rem;
+}
+
+.nav-icon svg {
+  height: 1.25rem;
+  width: 1.25rem;
+}
+
+.app-main {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+}
+
+.app-header {
+  background: var(--fnanz-surface);
+  border-bottom: 1px solid rgba(15, 23, 42, 0.08);
+  padding: 1.5rem 2rem;
+}
+
+.app-header h2 {
+  margin: 0;
+  font-size: 1.5rem;
+  font-weight: 600;
+}
+
+.app-main__content {
+  flex: 1;
   padding: 2rem 0;
 }
 
+.app-main__content .container {
+  max-width: 1100px;
+}
+
 .app-footer {
+  background: transparent;
+  color: rgba(31, 41, 55, 0.8);
   font-size: 0.875rem;
+  padding: 1.5rem 0 2rem;
+}
+
+@media (max-width: 960px) {
+  .app-layout {
+    flex-direction: column;
+  }
+
+  .app-sidebar {
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-between;
+    width: 100%;
+    gap: 1.5rem;
+  }
+
+  .app-sidebar__nav {
+    flex-direction: row;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+  }
+
+  .app-sidebar__nav a {
+    flex: 1 1 140px;
+    justify-content: center;
+  }
+
+  .app-main {
+    min-height: calc(100vh - 200px);
+  }
+}
+
+@media (max-width: 600px) {
+  .app-sidebar {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .app-sidebar__nav {
+    width: 100%;
+  }
+
+  .app-sidebar__nav a {
+    justify-content: flex-start;
+  }
 }

--- a/fnanz-app/src/app/app.routes.ts
+++ b/fnanz-app/src/app/app.routes.ts
@@ -2,6 +2,7 @@ import { Routes } from '@angular/router';
 
 import { DashboardComponent } from './features/dashboard/dashboard.component';
 import { CategoriasFinancierasComponent } from './features/categorias-financieras/categorias-financieras.component';
+import { GastosReservadosComponent } from './features/gastos-reservados/gastos-reservados.component';
 
 export const routes: Routes = [
   {
@@ -12,6 +13,10 @@ export const routes: Routes = [
   {
     path: 'categorias-financieras',
     component: CategoriasFinancierasComponent
+  },
+  {
+    path: 'gastos-reservados',
+    component: GastosReservadosComponent
   },
   {
     path: '**',

--- a/fnanz-app/src/app/core/services/gasto-reservado.service.ts
+++ b/fnanz-app/src/app/core/services/gasto-reservado.service.ts
@@ -1,0 +1,54 @@
+import { inject, Injectable } from '@angular/core';
+import { map, Observable } from 'rxjs';
+
+import {
+  GastoReservado,
+  GastoReservadoCreate,
+  GastoReservadoUpdate
+} from '../../shared/models/gasto-reservado.model';
+import { ApiHttpService } from './api-http.service';
+
+interface ApiResponse<T> {
+  message: string;
+  data: T;
+  timestamp: string;
+}
+
+@Injectable({
+  providedIn: 'root'
+})
+export class GastoReservadoService {
+  private readonly apiHttp = inject(ApiHttpService);
+  private readonly basePath = '/api/gastos-reservados';
+
+  list(query?: string): Observable<GastoReservado[]> {
+    const params: Record<string, unknown> = {
+      'pageable.page': 0,
+      'pageable.size': 50
+    };
+
+    if (query) {
+      params['q'] = query;
+    }
+
+    return this.apiHttp
+      .get<ApiResponse<GastoReservado[]>>(this.basePath, { params })
+      .pipe(map((response) => response.data ?? []));
+  }
+
+  create(payload: GastoReservadoCreate): Observable<GastoReservado> {
+    return this.apiHttp
+      .post<ApiResponse<GastoReservado>>(this.basePath, payload)
+      .pipe(map((response) => response.data));
+  }
+
+  update(id: number, payload: GastoReservadoUpdate): Observable<GastoReservado> {
+    return this.apiHttp
+      .patch<ApiResponse<GastoReservado>>(`${this.basePath}/${id}`, payload)
+      .pipe(map((response) => response.data));
+  }
+
+  delete(id: number): Observable<void> {
+    return this.apiHttp.delete<void>(`${this.basePath}/${id}`);
+  }
+}

--- a/fnanz-app/src/app/features/categorias-financieras/categorias-financieras.component.html
+++ b/fnanz-app/src/app/features/categorias-financieras/categorias-financieras.component.html
@@ -98,7 +98,12 @@
             <button type="button" class="ghost-button" (click)="startEdit(categoria)" [disabled]="loading() || saving()">
               Editar
             </button>
-            <button type="button" class="danger-button" (click)="deleteCategoria(categoria)" [disabled]="loading() || saving()">
+            <button
+              type="button"
+              class="danger-button"
+              (click)="promptDelete(categoria)"
+              [disabled]="loading() || saving()"
+            >
               Eliminar
             </button>
           </td>
@@ -112,4 +117,17 @@
       No hay categorías financieras registradas aún. Crea la primera para comenzar.
     </p>
   </ng-template>
+
+  <app-confirm-dialog
+    [open]="categoriaPendingDelete() !== null"
+    title="Eliminar categoría"
+    [message]="deleteMessage()"
+    confirmLabel="Eliminar"
+    cancelLabel="Cancelar"
+    busyLabel="Eliminando..."
+    [busy]="deleting()"
+    [confirmDestructive]="true"
+    (cancel)="closeDeleteDialog()"
+    (confirm)="confirmDeleteCategoria()"
+  ></app-confirm-dialog>
 </section>

--- a/fnanz-app/src/app/features/categorias-financieras/categorias-financieras.component.html
+++ b/fnanz-app/src/app/features/categorias-financieras/categorias-financieras.component.html
@@ -17,7 +17,7 @@
   <section *ngIf="showForm()" class="categoria-form">
     <h3>{{ formTitle() }}</h3>
     <form [formGroup]="form" (ngSubmit)="submitForm()" class="categoria-form__grid">
-      <label class="form-field">
+      <label class="form-field" [class.form-field--invalid]="hasControlError('nombre')">
         <span>Nombre *</span>
         <input type="text" formControlName="nombre" [class.invalid]="form.controls.nombre.touched && form.controls.nombre.invalid" />
         <small *ngIf="form.controls.nombre.touched && form.controls.nombre.hasError('required')">
@@ -26,28 +26,33 @@
         <small *ngIf="form.controls.nombre.touched && form.controls.nombre.hasError('maxlength')">
           El nombre debe tener menos de 120 caracteres.
         </small>
+        <small *ngIf="getServerError('nombre') as serverError">{{ serverError }}</small>
       </label>
 
-      <label class="form-field">
+      <label class="form-field" [class.form-field--invalid]="hasControlError('tipo')">
         <span>Tipo *</span>
         <select formControlName="tipo">
           <option *ngFor="let tipo of tipoOptions" [value]="tipo">{{ tipo }}</option>
         </select>
+        <small *ngIf="getServerError('tipo') as serverError">{{ serverError }}</small>
       </label>
 
-      <label class="form-field form-field--inline">
+      <label class="form-field form-field--inline" [class.form-field--invalid]="hasControlError('activo')">
         <input type="checkbox" formControlName="activo" />
         <span>Activo</span>
+        <small *ngIf="getServerError('activo') as serverError">{{ serverError }}</small>
       </label>
 
-      <label class="form-field">
+      <label class="form-field" [class.form-field--invalid]="hasControlError('orden')">
         <span>Orden</span>
         <input type="number" formControlName="orden" />
+        <small *ngIf="getServerError('orden') as serverError">{{ serverError }}</small>
       </label>
 
-      <label class="form-field form-field--full">
+      <label class="form-field form-field--full" [class.form-field--invalid]="hasControlError('descripcion')">
         <span>Descripción</span>
         <textarea rows="3" formControlName="descripcion"></textarea>
+        <small *ngIf="getServerError('descripcion') as serverError">{{ serverError }}</small>
       </label>
 
       <div class="form-actions">

--- a/fnanz-app/src/app/features/categorias-financieras/categorias-financieras.component.scss
+++ b/fnanz-app/src/app/features/categorias-financieras/categorias-financieras.component.scss
@@ -97,6 +97,10 @@
   font-weight: 600;
 }
 
+.form-field--invalid span {
+  color: #b91c1c;
+}
+
 .form-field input,
 .form-field select,
 .form-field textarea {
@@ -104,6 +108,12 @@
   border-radius: 0.65rem;
   font: inherit;
   padding: 0.6rem 0.75rem;
+}
+
+.form-field--invalid input,
+.form-field--invalid select,
+.form-field--invalid textarea {
+  border-color: #ef4444;
 }
 
 .form-field textarea {

--- a/fnanz-app/src/app/features/gastos-reservados/gastos-reservados.component.html
+++ b/fnanz-app/src/app/features/gastos-reservados/gastos-reservados.component.html
@@ -1,0 +1,171 @@
+<section class="card gasto-panel">
+  <header class="gasto-panel__header">
+    <div>
+      <h2>Gastos reservados</h2>
+      <p class="gasto-panel__subtitle">
+        Administra los compromisos de ingresos o egresos reservados para futuros períodos.
+      </p>
+    </div>
+    <button type="button" class="primary-button" (click)="startCreate()" [disabled]="loading() || saving()">
+      Nuevo gasto reservado
+    </button>
+  </header>
+
+  <p *ngIf="loading()" class="gasto-panel__loading">Cargando información...</p>
+  <p *ngIf="error() && !loading()" class="gasto-panel__error">{{ error() }}</p>
+  <p *ngIf="categoriasError()" class="gasto-panel__warning">{{ categoriasError() }}</p>
+
+  <section *ngIf="showForm()" class="gasto-form">
+    <h3>{{ formTitle() }}</h3>
+    <form [formGroup]="form" (ngSubmit)="submitForm()" class="gasto-form__grid">
+      <label class="form-field">
+        <span>Tipo *</span>
+        <select formControlName="tipo">
+          <option *ngFor="let tipo of tipoOptions" [value]="tipo">{{ tipo }}</option>
+        </select>
+      </label>
+
+      <label class="form-field">
+        <span>Categoría *</span>
+        <select formControlName="categoriaId" [disabled]="categoriasLoading() || categorias().length === 0">
+          <option [ngValue]="null" disabled>Seleccione una categoría</option>
+          <option *ngFor="let categoria of categorias()" [ngValue]="categoria.id">
+            {{ categoria.nombre }} ({{ categoria.tipo }})
+          </option>
+        </select>
+        <small *ngIf="form.controls.categoriaId.touched && form.controls.categoriaId.hasError('required')">
+          La categoría es obligatoria.
+        </small>
+        <small *ngIf="!categoriasLoading() && categorias().length === 0">
+          Debes crear al menos una categoría financiera para asignarla al gasto.
+        </small>
+      </label>
+
+      <label class="form-field">
+        <span>Concepto *</span>
+        <input type="text" formControlName="concepto" [class.invalid]="form.controls.concepto.touched && form.controls.concepto.invalid" />
+        <small *ngIf="form.controls.concepto.touched && form.controls.concepto.hasError('required')">
+          El concepto es obligatorio.
+        </small>
+        <small *ngIf="form.controls.concepto.touched && form.controls.concepto.hasError('maxlength')">
+          El concepto debe tener menos de 200 caracteres.
+        </small>
+      </label>
+
+      <label class="form-field">
+        <span>Periodo *</span>
+        <input type="date" formControlName="periodoFecha" [class.invalid]="form.controls.periodoFecha.touched && form.controls.periodoFecha.invalid" />
+        <small *ngIf="form.controls.periodoFecha.touched && form.controls.periodoFecha.hasError('required')">
+          El periodo es obligatorio.
+        </small>
+      </label>
+
+      <label class="form-field">
+        <span>Fecha de vencimiento</span>
+        <input type="date" formControlName="fechaVencimiento" />
+      </label>
+
+      <label class="form-field">
+        <span>Estado *</span>
+        <select formControlName="estado">
+          <option *ngFor="let estado of estadoOptions" [value]="estado">{{ estado }}</option>
+        </select>
+      </label>
+
+      <label class="form-field">
+        <span>Monto reservado *</span>
+        <input
+          type="number"
+          formControlName="montoReservado"
+          step="0.01"
+          min="0"
+          [class.invalid]="form.controls.montoReservado.touched && form.controls.montoReservado.invalid"
+        />
+        <small *ngIf="form.controls.montoReservado.touched && form.controls.montoReservado.hasError('required')">
+          El monto reservado es obligatorio.
+        </small>
+        <small *ngIf="form.controls.montoReservado.touched && form.controls.montoReservado.hasError('min')">
+          El monto reservado no puede ser negativo.
+        </small>
+      </label>
+
+      <label class="form-field">
+        <span>Monto aplicado</span>
+        <input type="number" formControlName="montoAplicado" step="0.01" min="0" />
+        <small *ngIf="form.controls.montoAplicado.touched && form.controls.montoAplicado.hasError('min')">
+          El monto aplicado no puede ser negativo.
+        </small>
+      </label>
+
+      <label class="form-field form-field--full">
+        <span>Nota</span>
+        <textarea rows="3" formControlName="nota"></textarea>
+        <small *ngIf="form.controls.nota.touched && form.controls.nota.hasError('maxlength')">
+          La nota debe tener menos de 500 caracteres.
+        </small>
+      </label>
+
+      <div class="form-actions">
+        <button type="button" class="ghost-button" (click)="cancelForm()">Cancelar</button>
+        <button type="submit" class="primary-button" [disabled]="saving()">
+          {{ saving() ? 'Guardando...' : 'Guardar' }}
+        </button>
+      </div>
+    </form>
+  </section>
+
+  <div class="gasto-grid" *ngIf="!loading() && gastos().length > 0; else emptyState">
+    <table class="data-table">
+      <thead>
+        <tr>
+          <th>Concepto</th>
+          <th>Tipo</th>
+          <th>Categoría</th>
+          <th>Estado</th>
+          <th>Periodo</th>
+          <th>Vencimiento</th>
+          <th>Monto reservado</th>
+          <th>Monto aplicado</th>
+          <th>Nota</th>
+          <th class="data-table__actions">Acciones</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr *ngFor="let gasto of gastos(); trackBy: trackByGastoId">
+          <td>
+            <div class="gasto-name">{{ gasto.concepto }}</div>
+            <small class="gasto-meta">Actualizado {{ gasto.actualizadoEn | date: 'short' }}</small>
+          </td>
+          <td>
+            <span class="tipo-pill" [ngClass]="gasto.tipo === 'INGRESO' ? 'tipo-pill--ingreso' : 'tipo-pill--egreso'">
+              {{ gasto.tipo }}
+            </span>
+          </td>
+          <td>{{ gasto.categoriaNombre }}</td>
+          <td>
+            <span [ngClass]="'estado estado--' + gasto.estado.toLowerCase()">{{ gasto.estado }}</span>
+          </td>
+          <td>{{ gasto.periodoFecha | date: 'longDate' }}</td>
+          <td>{{ gasto.fechaVencimiento ? (gasto.fechaVencimiento | date: 'longDate') : '—' }}</td>
+          <td>{{ gasto.montoReservado | number: '1.2-2' }}</td>
+          <td>{{ gasto.montoAplicado != null ? (gasto.montoAplicado | number: '1.2-2') : '—' }}</td>
+          <td>{{ gasto.nota || '—' }}</td>
+          <td class="data-table__actions">
+            <button type="button" class="ghost-button" (click)="startEdit(gasto)" [disabled]="loading() || saving()">
+              Editar
+            </button>
+            <button type="button" class="danger-button" (click)="deleteGasto(gasto)" [disabled]="loading() || saving()">
+              Eliminar
+            </button>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+
+  <ng-template #emptyState>
+    <p class="gasto-panel__empty" *ngIf="!loading()">
+      No hay gastos reservados registrados. Registra uno nuevo para comenzar.
+    </p>
+  </ng-template>
+</section>

--- a/fnanz-app/src/app/features/gastos-reservados/gastos-reservados.component.html
+++ b/fnanz-app/src/app/features/gastos-reservados/gastos-reservados.component.html
@@ -163,7 +163,12 @@
             <button type="button" class="ghost-button" (click)="startEdit(gasto)" [disabled]="loading() || saving()">
               Editar
             </button>
-            <button type="button" class="danger-button" (click)="deleteGasto(gasto)" [disabled]="loading() || saving()">
+            <button
+              type="button"
+              class="danger-button"
+              (click)="promptDelete(gasto)"
+              [disabled]="loading() || saving()"
+            >
               Eliminar
             </button>
           </td>
@@ -177,4 +182,17 @@
       No hay gastos reservados registrados. Registra uno nuevo para comenzar.
     </p>
   </ng-template>
+
+  <app-confirm-dialog
+    [open]="gastoPendingDelete() !== null"
+    title="Eliminar gasto reservado"
+    [message]="deleteMessage()"
+    confirmLabel="Eliminar"
+    cancelLabel="Cancelar"
+    busyLabel="Eliminando..."
+    [busy]="deleting()"
+    [confirmDestructive]="true"
+    (cancel)="closeDeleteDialog()"
+    (confirm)="confirmDeleteGasto()"
+  ></app-confirm-dialog>
 </section>

--- a/fnanz-app/src/app/features/gastos-reservados/gastos-reservados.component.html
+++ b/fnanz-app/src/app/features/gastos-reservados/gastos-reservados.component.html
@@ -18,14 +18,15 @@
   <section *ngIf="showForm()" class="gasto-form">
     <h3>{{ formTitle() }}</h3>
     <form [formGroup]="form" (ngSubmit)="submitForm()" class="gasto-form__grid">
-      <label class="form-field">
+      <label class="form-field" [class.form-field--invalid]="hasControlError('tipo')">
         <span>Tipo *</span>
         <select formControlName="tipo">
           <option *ngFor="let tipo of tipoOptions" [value]="tipo">{{ tipo }}</option>
         </select>
+        <small *ngIf="getServerError('tipo') as serverError">{{ serverError }}</small>
       </label>
 
-      <label class="form-field">
+      <label class="form-field" [class.form-field--invalid]="hasControlError('categoriaId')">
         <span>Categoría *</span>
         <select formControlName="categoriaId" [disabled]="categoriasLoading() || categorias().length === 0">
           <option [ngValue]="null" disabled>Seleccione una categoría</option>
@@ -36,12 +37,13 @@
         <small *ngIf="form.controls.categoriaId.touched && form.controls.categoriaId.hasError('required')">
           La categoría es obligatoria.
         </small>
+        <small *ngIf="getServerError('categoriaId') as serverError">{{ serverError }}</small>
         <small *ngIf="!categoriasLoading() && categorias().length === 0">
           Debes crear al menos una categoría financiera para asignarla al gasto.
         </small>
       </label>
 
-      <label class="form-field">
+      <label class="form-field" [class.form-field--invalid]="hasControlError('concepto')">
         <span>Concepto *</span>
         <input type="text" formControlName="concepto" [class.invalid]="form.controls.concepto.touched && form.controls.concepto.invalid" />
         <small *ngIf="form.controls.concepto.touched && form.controls.concepto.hasError('required')">
@@ -50,29 +52,33 @@
         <small *ngIf="form.controls.concepto.touched && form.controls.concepto.hasError('maxlength')">
           El concepto debe tener menos de 200 caracteres.
         </small>
+        <small *ngIf="getServerError('concepto') as serverError">{{ serverError }}</small>
       </label>
 
-      <label class="form-field">
+      <label class="form-field" [class.form-field--invalid]="hasControlError('periodoFecha')">
         <span>Periodo *</span>
         <input type="date" formControlName="periodoFecha" [class.invalid]="form.controls.periodoFecha.touched && form.controls.periodoFecha.invalid" />
         <small *ngIf="form.controls.periodoFecha.touched && form.controls.periodoFecha.hasError('required')">
           El periodo es obligatorio.
         </small>
+        <small *ngIf="getServerError('periodoFecha') as serverError">{{ serverError }}</small>
       </label>
 
-      <label class="form-field">
+      <label class="form-field" [class.form-field--invalid]="hasControlError('fechaVencimiento')">
         <span>Fecha de vencimiento</span>
         <input type="date" formControlName="fechaVencimiento" />
+        <small *ngIf="getServerError('fechaVencimiento') as serverError">{{ serverError }}</small>
       </label>
 
-      <label class="form-field">
+      <label class="form-field" [class.form-field--invalid]="hasControlError('estado')">
         <span>Estado *</span>
         <select formControlName="estado">
           <option *ngFor="let estado of estadoOptions" [value]="estado">{{ estado }}</option>
         </select>
+        <small *ngIf="getServerError('estado') as serverError">{{ serverError }}</small>
       </label>
 
-      <label class="form-field">
+      <label class="form-field" [class.form-field--invalid]="hasControlError('montoReservado')">
         <span>Monto reservado *</span>
         <input
           type="number"
@@ -87,22 +93,25 @@
         <small *ngIf="form.controls.montoReservado.touched && form.controls.montoReservado.hasError('min')">
           El monto reservado no puede ser negativo.
         </small>
+        <small *ngIf="getServerError('montoReservado') as serverError">{{ serverError }}</small>
       </label>
 
-      <label class="form-field">
+      <label class="form-field" [class.form-field--invalid]="hasControlError('montoAplicado')">
         <span>Monto aplicado</span>
         <input type="number" formControlName="montoAplicado" step="0.01" min="0" />
         <small *ngIf="form.controls.montoAplicado.touched && form.controls.montoAplicado.hasError('min')">
           El monto aplicado no puede ser negativo.
         </small>
+        <small *ngIf="getServerError('montoAplicado') as serverError">{{ serverError }}</small>
       </label>
 
-      <label class="form-field form-field--full">
+      <label class="form-field form-field--full" [class.form-field--invalid]="hasControlError('nota')">
         <span>Nota</span>
         <textarea rows="3" formControlName="nota"></textarea>
         <small *ngIf="form.controls.nota.touched && form.controls.nota.hasError('maxlength')">
           La nota debe tener menos de 500 caracteres.
         </small>
+        <small *ngIf="getServerError('nota') as serverError">{{ serverError }}</small>
       </label>
 
       <div class="form-actions">

--- a/fnanz-app/src/app/features/gastos-reservados/gastos-reservados.component.scss
+++ b/fnanz-app/src/app/features/gastos-reservados/gastos-reservados.component.scss
@@ -1,0 +1,238 @@
+.gasto-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.gasto-panel__header {
+  align-items: flex-start;
+  display: flex;
+  gap: 1rem;
+  justify-content: space-between;
+  flex-wrap: wrap;
+}
+
+.gasto-panel__subtitle {
+  color: #6b7280;
+  margin: 0.25rem 0 0;
+}
+
+.primary-button,
+.ghost-button,
+.danger-button {
+  border: none;
+  border-radius: 0.75rem;
+  cursor: pointer;
+  font-weight: 600;
+  padding: 0.65rem 1.4rem;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+.primary-button {
+  background: linear-gradient(90deg, var(--fnanz-primary), var(--fnanz-secondary));
+  color: #fff;
+  box-shadow: 0 8px 18px rgba(0, 80, 179, 0.25);
+}
+
+.primary-button:disabled {
+  cursor: not-allowed;
+  opacity: 0.6;
+  box-shadow: none;
+}
+
+.ghost-button {
+  background: #f3f4f6;
+  color: var(--fnanz-primary);
+}
+
+.danger-button {
+  background: #fee2e2;
+  color: #b91c1c;
+}
+
+.ghost-button:hover:not(:disabled),
+.danger-button:hover:not(:disabled),
+.primary-button:hover:not(:disabled) {
+  transform: translateY(-1px);
+}
+
+.gasto-panel__loading,
+.gasto-panel__error,
+.gasto-panel__warning,
+.gasto-panel__empty {
+  background-color: #f9fafb;
+  border-radius: 0.75rem;
+  padding: 1rem;
+  margin: 0;
+}
+
+.gasto-panel__error {
+  background-color: #fee2e2;
+  color: #991b1b;
+}
+
+.gasto-panel__warning {
+  background-color: #fef9c3;
+  color: #854d0e;
+}
+
+.gasto-form {
+  background-color: #f9fafb;
+  border-radius: 1rem;
+  padding: 1.5rem;
+}
+
+.gasto-form h3 {
+  margin-top: 0;
+}
+
+.gasto-form__grid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.form-field {
+  display: flex;
+  flex-direction: column;
+  font-size: 0.95rem;
+  gap: 0.35rem;
+}
+
+.form-field span {
+  font-weight: 600;
+}
+
+.form-field input,
+.form-field select,
+.form-field textarea {
+  border: 1px solid #d1d5db;
+  border-radius: 0.65rem;
+  font: inherit;
+  padding: 0.6rem 0.75rem;
+}
+
+.form-field textarea {
+  resize: vertical;
+}
+
+.form-field input.invalid {
+  border-color: #ef4444;
+}
+
+.form-field small {
+  color: #b91c1c;
+  font-size: 0.75rem;
+}
+
+.form-field--full {
+  grid-column: 1 / -1;
+}
+
+.form-actions {
+  align-items: center;
+  display: flex;
+  gap: 1rem;
+  grid-column: 1 / -1;
+  justify-content: flex-end;
+}
+
+.data-table {
+  border-collapse: collapse;
+  width: 100%;
+}
+
+.data-table th,
+.data-table td {
+  border-bottom: 1px solid #e5e7eb;
+  padding: 0.75rem 1rem;
+  text-align: left;
+  vertical-align: top;
+}
+
+.data-table thead th {
+  color: #6b7280;
+  font-size: 0.85rem;
+  font-weight: 600;
+  text-transform: uppercase;
+}
+
+.data-table tbody tr:hover {
+  background-color: #f9fafb;
+}
+
+.data-table__actions {
+  text-align: right;
+  white-space: nowrap;
+}
+
+.gasto-name {
+  font-weight: 600;
+}
+
+.gasto-meta {
+  color: #6b7280;
+}
+
+.tipo-pill {
+  border-radius: 999px;
+  color: #fff;
+  display: inline-block;
+  font-size: 0.75rem;
+  font-weight: 600;
+  padding: 0.25rem 0.75rem;
+}
+
+.tipo-pill--ingreso {
+  background-color: #047857;
+}
+
+.tipo-pill--egreso {
+  background-color: #1d4ed8;
+}
+
+.estado {
+  border-radius: 999px;
+  display: inline-block;
+  font-size: 0.75rem;
+  font-weight: 600;
+  padding: 0.25rem 0.75rem;
+}
+
+.estado--reservado {
+  background-color: #e0f2fe;
+  color: #0369a1;
+}
+
+.estado--aplicado {
+  background-color: #dcfce7;
+  color: #166534;
+}
+
+.estado--cancelado {
+  background-color: #fee2e2;
+  color: #b91c1c;
+}
+
+@media (max-width: 640px) {
+  .data-table thead {
+    display: none;
+  }
+
+  .data-table tbody tr {
+    display: grid;
+    gap: 0.75rem;
+    padding: 1rem 0;
+  }
+
+  .data-table td {
+    border: none;
+    padding: 0;
+  }
+
+  .data-table__actions {
+    display: flex;
+    gap: 0.5rem;
+    justify-content: flex-end;
+  }
+}

--- a/fnanz-app/src/app/features/gastos-reservados/gastos-reservados.component.scss
+++ b/fnanz-app/src/app/features/gastos-reservados/gastos-reservados.component.scss
@@ -103,6 +103,10 @@
   font-weight: 600;
 }
 
+.form-field--invalid span {
+  color: #b91c1c;
+}
+
 .form-field input,
 .form-field select,
 .form-field textarea {
@@ -110,6 +114,12 @@
   border-radius: 0.65rem;
   font: inherit;
   padding: 0.6rem 0.75rem;
+}
+
+.form-field--invalid input,
+.form-field--invalid select,
+.form-field--invalid textarea {
+  border-color: #ef4444;
 }
 
 .form-field textarea {

--- a/fnanz-app/src/app/features/gastos-reservados/gastos-reservados.component.ts
+++ b/fnanz-app/src/app/features/gastos-reservados/gastos-reservados.component.ts
@@ -137,11 +137,14 @@ export class GastosReservadosComponent implements OnInit {
   }
 
   submitForm(): void {
+    this.clearFormErrors();
+
     if (this.form.invalid) {
       this.form.markAllAsTouched();
       return;
     }
 
+    this.error.set(null);
     const formValue = this.form.getRawValue();
     const payload: GastoReservadoCreate = {
       tipo: formValue.tipo,
@@ -178,8 +181,13 @@ export class GastosReservadosComponent implements OnInit {
         this.selectedGasto.set(null);
         this.loadGastos();
       },
-      error: () => {
-        this.error.set('Ocurrió un error al guardar el gasto reservado.');
+      error: (err) => {
+        const handled = this.handleFormApiErrors(err);
+        if (handled) {
+          this.error.set('Revisa los errores marcados en el formulario.');
+        } else {
+          this.error.set('Ocurrió un error al guardar el gasto reservado.');
+        }
         this.saving.set(false);
       }
     });
@@ -203,5 +211,63 @@ export class GastosReservadosComponent implements OnInit {
         this.loading.set(false);
       }
     });
+  }
+
+  hasControlError(controlName: keyof typeof this.form.controls): boolean {
+    const control = this.form.controls[controlName];
+    return control?.touched === true && control.invalid;
+  }
+
+  getServerError(controlName: keyof typeof this.form.controls): string | null {
+    const control = this.form.controls[controlName];
+    const apiError = control?.errors?.['api'];
+    return typeof apiError === 'string' ? apiError : null;
+  }
+
+  private clearFormErrors(): void {
+    Object.values(this.form.controls).forEach((control) => {
+      if (!control.errors) {
+        return;
+      }
+
+      const { api, ...otherErrors } = control.errors;
+      if (api) {
+        const hasOtherErrors = Object.keys(otherErrors).length > 0;
+        control.setErrors(hasOtherErrors ? otherErrors : null);
+      }
+    });
+  }
+
+  private handleFormApiErrors(error: unknown): boolean {
+    if (!error || typeof error !== 'object') {
+      return false;
+    }
+
+    const httpError = error as { status?: number; error?: unknown };
+    if (!httpError.status || httpError.status < 400 || httpError.status >= 500) {
+      return false;
+    }
+
+    const payload = httpError.error as
+      | { messages?: { field: string; message: string }[] }
+      | undefined;
+
+    if (!payload?.messages?.length) {
+      return false;
+    }
+
+    let applied = false;
+
+    payload.messages.forEach(({ field, message }) => {
+      const control = this.form.get(field);
+      if (control) {
+        const existingErrors = control.errors ?? {};
+        control.setErrors({ ...existingErrors, api: message });
+        control.markAsTouched();
+        applied = true;
+      }
+    });
+
+    return applied;
   }
 }

--- a/fnanz-app/src/app/features/gastos-reservados/gastos-reservados.component.ts
+++ b/fnanz-app/src/app/features/gastos-reservados/gastos-reservados.component.ts
@@ -1,0 +1,207 @@
+import { DatePipe, DecimalPipe, NgClass, NgFor, NgIf } from '@angular/common';
+import { Component, OnInit, computed, inject, signal } from '@angular/core';
+import { FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
+
+import { CategoriaFinanciera } from '../../shared/models/categoria-financiera.model';
+import {
+  GastoReservado,
+  GastoReservadoCreate
+} from '../../shared/models/gasto-reservado.model';
+import { CategoriaFinancieraService } from '../../core/services/categoria-financiera.service';
+import { GastoReservadoService } from '../../core/services/gasto-reservado.service';
+
+@Component({
+  selector: 'app-gastos-reservados',
+  standalone: true,
+  imports: [DatePipe, DecimalPipe, NgClass, NgFor, NgIf, ReactiveFormsModule],
+  templateUrl: './gastos-reservados.component.html',
+  styleUrls: ['./gastos-reservados.component.scss']
+})
+export class GastosReservadosComponent implements OnInit {
+  private readonly gastoService = inject(GastoReservadoService);
+  private readonly categoriaService = inject(CategoriaFinancieraService);
+  private readonly formBuilder = inject(FormBuilder);
+
+  readonly gastos = signal<GastoReservado[]>([]);
+  readonly categorias = signal<CategoriaFinanciera[]>([]);
+  readonly loading = signal(false);
+  readonly saving = signal(false);
+  readonly categoriasLoading = signal(false);
+  readonly error = signal<string | null>(null);
+  readonly categoriasError = signal<string | null>(null);
+  readonly selectedGasto = signal<GastoReservado | null>(null);
+  readonly showForm = signal(false);
+  readonly tipoOptions: GastoReservado['tipo'][] = ['INGRESO', 'EGRESO'];
+  readonly estadoOptions: GastoReservado['estado'][] = [
+    'RESERVADO',
+    'APLICADO',
+    'CANCELADO'
+  ];
+
+  readonly form = this.formBuilder.nonNullable.group({
+    tipo: ['EGRESO' as GastoReservado['tipo'], Validators.required],
+    categoriaId: this.formBuilder.control<number | null>(null, Validators.required),
+    concepto: ['', [Validators.required, Validators.maxLength(200)]],
+    periodoFecha: ['', Validators.required],
+    fechaVencimiento: this.formBuilder.control<string | null>(null),
+    estado: ['RESERVADO' as GastoReservado['estado'], Validators.required],
+    montoReservado: this.formBuilder.control<number | null>(null, [
+      Validators.required,
+      Validators.min(0)
+    ]),
+    montoAplicado: this.formBuilder.control<number | null>(null, [Validators.min(0)]),
+    nota: ['', Validators.maxLength(500)]
+  });
+
+  readonly formTitle = computed(() =>
+    this.selectedGasto()
+      ? `Editar gasto reservado: ${this.selectedGasto()!.concepto}`
+      : 'Nuevo gasto reservado'
+  );
+
+  ngOnInit(): void {
+    this.loadGastos();
+    this.loadCategorias();
+  }
+
+  trackByGastoId = (_: number, gasto: GastoReservado): number => gasto.id;
+
+  private loadCategorias(): void {
+    this.categoriasLoading.set(true);
+    this.categoriasError.set(null);
+
+    this.categoriaService.list().subscribe({
+      next: (categorias) => {
+        this.categorias.set(categorias);
+        this.categoriasLoading.set(false);
+      },
+      error: () => {
+        this.categoriasError.set('No se pudieron cargar las categorías financieras.');
+        this.categoriasLoading.set(false);
+      }
+    });
+  }
+
+  loadGastos(): void {
+    this.loading.set(true);
+    this.error.set(null);
+
+    this.gastoService.list().subscribe({
+      next: (gastos) => {
+        this.gastos.set(gastos);
+        this.loading.set(false);
+      },
+      error: () => {
+        this.error.set('No se pudieron cargar los gastos reservados.');
+        this.loading.set(false);
+      }
+    });
+  }
+
+  startCreate(): void {
+    this.selectedGasto.set(null);
+    this.form.reset({
+      tipo: 'EGRESO',
+      categoriaId: null,
+      concepto: '',
+      periodoFecha: '',
+      fechaVencimiento: null,
+      estado: 'RESERVADO',
+      montoReservado: null,
+      montoAplicado: null,
+      nota: ''
+    });
+    this.showForm.set(true);
+  }
+
+  startEdit(gasto: GastoReservado): void {
+    this.selectedGasto.set(gasto);
+    this.form.reset({
+      tipo: gasto.tipo,
+      categoriaId: gasto.categoriaId,
+      concepto: gasto.concepto,
+      periodoFecha: gasto.periodoFecha,
+      fechaVencimiento: gasto.fechaVencimiento ?? null,
+      estado: gasto.estado,
+      montoReservado: gasto.montoReservado,
+      montoAplicado: gasto.montoAplicado ?? null,
+      nota: gasto.nota ?? ''
+    });
+    this.showForm.set(true);
+  }
+
+  cancelForm(): void {
+    this.form.reset();
+    this.showForm.set(false);
+    this.selectedGasto.set(null);
+  }
+
+  submitForm(): void {
+    if (this.form.invalid) {
+      this.form.markAllAsTouched();
+      return;
+    }
+
+    const formValue = this.form.getRawValue();
+    const payload: GastoReservadoCreate = {
+      tipo: formValue.tipo,
+      categoriaId: Number(formValue.categoriaId),
+      concepto: formValue.concepto.trim(),
+      periodoFecha: formValue.periodoFecha,
+      estado: formValue.estado,
+      montoReservado: Number(formValue.montoReservado)
+    };
+
+    if (formValue.fechaVencimiento) {
+      payload.fechaVencimiento = formValue.fechaVencimiento;
+    }
+
+    if (formValue.montoAplicado !== null && formValue.montoAplicado !== undefined) {
+      payload.montoAplicado = Number(formValue.montoAplicado);
+    }
+
+    if (formValue.nota?.trim()) {
+      payload.nota = formValue.nota.trim();
+    }
+
+    const selected = this.selectedGasto();
+    this.saving.set(true);
+
+    const request = selected
+      ? this.gastoService.update(selected.id, { ...payload })
+      : this.gastoService.create(payload);
+
+    request.subscribe({
+      next: () => {
+        this.saving.set(false);
+        this.showForm.set(false);
+        this.selectedGasto.set(null);
+        this.loadGastos();
+      },
+      error: () => {
+        this.error.set('Ocurrió un error al guardar el gasto reservado.');
+        this.saving.set(false);
+      }
+    });
+  }
+
+  deleteGasto(gasto: GastoReservado): void {
+    const confirmDelete = window.confirm(
+      `¿Desea eliminar el gasto reservado "${gasto.concepto}"?`
+    );
+
+    if (!confirmDelete) {
+      return;
+    }
+
+    this.loading.set(true);
+
+    this.gastoService.delete(gasto.id).subscribe({
+      next: () => this.loadGastos(),
+      error: () => {
+        this.error.set('No se pudo eliminar el gasto reservado seleccionado.');
+        this.loading.set(false);
+      }
+    });
+  }
+}

--- a/fnanz-app/src/app/shared/components/confirm-dialog/confirm-dialog.component.html
+++ b/fnanz-app/src/app/shared/components/confirm-dialog/confirm-dialog.component.html
@@ -1,0 +1,29 @@
+<div *ngIf="open" class="modal" role="dialog" aria-modal="true" (click)="handleBackdropClick($event)">
+  <div class="modal-dialog modal-dialog-centered">
+    <div class="modal-content">
+      <header class="modal-header">
+        <h5 class="modal-title">{{ title }}</h5>
+        <button type="button" class="modal-close" aria-label="Cerrar" (click)="onCancel()" [disabled]="busy">
+          &times;
+        </button>
+      </header>
+      <section class="modal-body">
+        <p>{{ message }}</p>
+      </section>
+      <footer class="modal-footer">
+        <button type="button" class="ghost-button" (click)="onCancel()" [disabled]="busy">
+          {{ cancelLabel }}
+        </button>
+        <button
+          type="button"
+          [ngClass]="confirmButtonClass"
+          (click)="onConfirm()"
+          [disabled]="busy"
+        >
+          {{ busy ? busyLabel : confirmLabel }}
+        </button>
+      </footer>
+    </div>
+  </div>
+</div>
+<div *ngIf="open" class="modal-backdrop"></div>

--- a/fnanz-app/src/app/shared/components/confirm-dialog/confirm-dialog.component.scss
+++ b/fnanz-app/src/app/shared/components/confirm-dialog/confirm-dialog.component.scss
@@ -1,0 +1,93 @@
+.modal {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1050;
+  padding: 1.5rem;
+}
+
+.modal-dialog {
+  width: 100%;
+  max-width: 420px;
+}
+
+.modal-content {
+  background: var(--fnanz-surface);
+  border-radius: 1rem;
+  box-shadow: 0 20px 60px rgba(15, 23, 42, 0.18);
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+
+.modal-header,
+.modal-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  padding: 1.25rem 1.5rem;
+}
+
+.modal-header {
+  border-bottom: 1px solid rgba(15, 23, 42, 0.08);
+}
+
+.modal-title {
+  font-size: 1.1rem;
+  font-weight: 600;
+  margin: 0;
+}
+
+.modal-close {
+  border: none;
+  background: transparent;
+  color: #64748b;
+  font-size: 1.75rem;
+  line-height: 1;
+  cursor: pointer;
+  padding: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: color 0.2s ease;
+
+  &:hover:not(:disabled) {
+    color: #0f172a;
+  }
+
+  &:disabled {
+    cursor: not-allowed;
+    opacity: 0.6;
+  }
+}
+
+.modal-body {
+  padding: 1.25rem 1.5rem;
+  color: #334155;
+  line-height: 1.5;
+}
+
+.modal-footer {
+  border-top: 1px solid rgba(15, 23, 42, 0.08);
+  justify-content: flex-end;
+}
+
+.modal-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(15, 23, 42, 0.55);
+  z-index: 1040;
+}
+
+@media (max-width: 480px) {
+  .modal {
+    padding: 1rem;
+  }
+
+  .modal-content {
+    border-radius: 0.75rem;
+  }
+}

--- a/fnanz-app/src/app/shared/components/confirm-dialog/confirm-dialog.component.ts
+++ b/fnanz-app/src/app/shared/components/confirm-dialog/confirm-dialog.component.ts
@@ -1,0 +1,63 @@
+import { NgClass, NgIf } from '@angular/common';
+import { Component, EventEmitter, HostListener, Input, Output } from '@angular/core';
+
+@Component({
+  selector: 'app-confirm-dialog',
+  standalone: true,
+  imports: [NgClass, NgIf],
+  templateUrl: './confirm-dialog.component.html',
+  styleUrls: ['./confirm-dialog.component.scss'],
+})
+export class ConfirmDialogComponent {
+  @Input({ required: true }) open = false;
+  @Input({ required: true }) title = '';
+  @Input({ required: true }) message = '';
+  @Input() confirmLabel = 'Confirmar';
+  @Input() cancelLabel = 'Cancelar';
+  @Input() busyLabel = 'Procesando...';
+  @Input() busy = false;
+  @Input() confirmDestructive = false;
+
+  @Output() cancel = new EventEmitter<void>();
+  @Output() confirm = new EventEmitter<void>();
+
+  @HostListener('document:keydown.escape', ['$event'])
+  onEscape(event: KeyboardEvent): void {
+    if (!this.open || this.busy) {
+      return;
+    }
+
+    event.preventDefault();
+    this.cancel.emit();
+  }
+
+  handleBackdropClick(event: MouseEvent): void {
+    if (this.busy) {
+      return;
+    }
+
+    if (event.target instanceof HTMLElement && event.target.classList.contains('modal')) {
+      this.cancel.emit();
+    }
+  }
+
+  onCancel(): void {
+    if (this.busy) {
+      return;
+    }
+
+    this.cancel.emit();
+  }
+
+  onConfirm(): void {
+    if (this.busy) {
+      return;
+    }
+
+    this.confirm.emit();
+  }
+
+  get confirmButtonClass(): string {
+    return this.confirmDestructive ? 'danger-button' : 'primary-button';
+  }
+}

--- a/fnanz-app/src/app/shared/models/gasto-reservado.model.ts
+++ b/fnanz-app/src/app/shared/models/gasto-reservado.model.ts
@@ -1,0 +1,29 @@
+export interface GastoReservado {
+  id: number;
+  tipo: 'INGRESO' | 'EGRESO';
+  categoriaId: number;
+  categoriaNombre: string;
+  concepto: string;
+  periodoFecha: string;
+  fechaVencimiento?: string | null;
+  estado: 'RESERVADO' | 'APLICADO' | 'CANCELADO';
+  montoReservado: number;
+  montoAplicado?: number | null;
+  nota?: string | null;
+  creadoEn: string;
+  actualizadoEn: string;
+}
+
+export type GastoReservadoCreate = {
+  tipo: GastoReservado['tipo'];
+  categoriaId: number;
+  concepto: string;
+  periodoFecha: string;
+  estado: GastoReservado['estado'];
+  montoReservado: number;
+  fechaVencimiento?: string | null;
+  montoAplicado?: number | null;
+  nota?: string;
+};
+
+export type GastoReservadoUpdate = Partial<GastoReservadoCreate>;


### PR DESCRIPTION
## Summary
- agrega modelo, servicio y componentes standalone para gestionar gastos reservados
- vincula la navegación y rutas principales con la nueva pantalla de administración

## Testing
- CI=true npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dbf6804c18832f82f9549fa75eb650