### PR TITLE
Add reservas resumen screen for financial periods

### DIFF
--- a/fnanz-app/src/app/app.routes.ts
+++ b/fnanz-app/src/app/app.routes.ts
@@ -4,6 +4,7 @@ import { DashboardComponent } from './features/dashboard/dashboard.component';
 import { CategoriasFinancierasComponent } from './features/categorias-financieras/categorias-financieras.component';
 import { GastosReservadosComponent } from './features/gastos-reservados/gastos-reservados.component';
 import { PeriodosFinancierosComponent } from './features/periodos-financieros/periodos-financieros.component';
+import { ReservasResumenComponent } from './features/periodos-financieros/reservas-resumen/reservas-resumen.component';
 
 export const routes: Routes = [
   {
@@ -22,6 +23,10 @@ export const routes: Routes = [
   {
     path: 'periodos-financieros',
     component: PeriodosFinancierosComponent
+  },
+  {
+    path: 'periodos-financieros/:id/reservas-resumen',
+    component: ReservasResumenComponent
   },
   {
     path: '**',

--- a/fnanz-app/src/app/core/services/periodo-financiero.service.ts
+++ b/fnanz-app/src/app/core/services/periodo-financiero.service.ts
@@ -4,6 +4,7 @@ import { map, Observable } from 'rxjs';
 import {
   PeriodoFinanciero,
   PeriodoFinancieroCreate,
+  PeriodoFinancieroReservasResumen,
   PeriodoFinancieroUpdate
 } from '../../shared/models/periodo-financiero.model';
 import { ApiHttpService } from './api-http.service';
@@ -50,5 +51,15 @@ export class PeriodoFinancieroService {
 
   delete(id: number): Observable<void> {
     return this.apiHttp.delete<void>(`${this.basePath}/${id}`);
+  }
+
+  getReservasResumen(
+    id: number
+  ): Observable<PeriodoFinancieroReservasResumen | null> {
+    return this.apiHttp
+      .get<ApiResponse<PeriodoFinancieroReservasResumen | null>>(
+        `${this.basePath}/${id}/reservas-resumen`
+      )
+      .pipe(map((response) => response.data ?? null));
   }
 }

--- a/fnanz-app/src/app/features/periodos-financieros/periodos-financieros.component.html
+++ b/fnanz-app/src/app/features/periodos-financieros/periodos-financieros.component.html
@@ -106,6 +106,14 @@
           </td>
           <td>{{ periodo.descripcion || 'Sin descripción' }}</td>
           <td class="data-table__actions">
+            <button
+              type="button"
+              class="ghost-button"
+              [routerLink]="['/periodos-financieros', periodo.id, 'reservas-resumen']"
+              [state]="{ periodoNombre: periodo.nombre }"
+            >
+              Ver resumen
+            </button>
             <button type="button" class="ghost-button" (click)="startEdit(periodo)" [disabled]="loading() || saving()">
               Editar
             </button>

--- a/fnanz-app/src/app/features/periodos-financieros/periodos-financieros.component.ts
+++ b/fnanz-app/src/app/features/periodos-financieros/periodos-financieros.component.ts
@@ -1,5 +1,6 @@
 import { DatePipe, NgClass, NgFor, NgIf } from '@angular/common';
 import { Component, OnInit, computed, inject, signal } from '@angular/core';
+import { RouterLink } from '@angular/router';
 import { FormBuilder, ReactiveFormsModule, ValidatorFn, Validators } from '@angular/forms';
 
 import {
@@ -19,6 +20,7 @@ import { ConfirmDialogComponent } from '../../shared/components/confirm-dialog/c
     NgFor,
     NgIf,
     ReactiveFormsModule,
+    RouterLink,
   ],
   templateUrl: './periodos-financieros.component.html',
   styleUrls: ['./periodos-financieros.component.scss']

--- a/fnanz-app/src/app/features/periodos-financieros/reservas-resumen/reservas-resumen.component.html
+++ b/fnanz-app/src/app/features/periodos-financieros/reservas-resumen/reservas-resumen.component.html
@@ -1,0 +1,124 @@
+<section class="card resumen-panel">
+  <header class="resumen-panel__header">
+    <div>
+      <h2>Resumen de reservas por categoría</h2>
+      <p class="resumen-panel__subtitle">
+        Periodo:
+        <span *ngIf="periodoNombre(); else periodoFallback">{{ periodoNombre() }}</span>
+        <ng-template #periodoFallback>
+          {{ periodoId() ? ('#' + periodoId()) : 'Desconocido' }}
+        </ng-template>
+      </p>
+    </div>
+    <button type="button" class="ghost-button" routerLink="/periodos-financieros">
+      Volver a periodos
+    </button>
+  </header>
+
+  <p *ngIf="loading()" class="resumen-panel__loading">Cargando resumen...</p>
+  <p *ngIf="error() && !loading()" class="resumen-panel__error">{{ error() }}</p>
+
+  <ng-container *ngIf="!loading() && resumen() as resumenData">
+    <ng-container *ngIf="resumenData; else emptyState">
+      <section class="resumen-grid">
+        <article class="resumen-card">
+          <header>
+            <h3>Ingresos</h3>
+            <span class="monto-pill monto-pill--ingreso">
+              Reservado: {{ resumenData.totalIngresos.montoReservado | number: '1.2-2' }}
+            </span>
+          </header>
+
+          <p *ngIf="resumenData.ingresos.length === 0" class="resumen-card__empty">
+            No hay ingresos reservados para este periodo.
+          </p>
+
+          <table *ngIf="resumenData.ingresos.length > 0" class="resumen-table">
+            <thead>
+              <tr>
+                <th>Categoría</th>
+                <th>Reservado</th>
+                <th>Aplicado</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr *ngFor="let ingreso of resumenData.ingresos; trackBy: trackByCategoriaId">
+                <td>
+                  <div class="categoria-nombre">{{ ingreso.categoriaNombre }}</div>
+                  <small *ngIf="ingreso.orden != null" class="categoria-orden">Orden {{ ingreso.orden }}</small>
+                </td>
+                <td>{{ ingreso.montoReservado | number: '1.2-2' }}</td>
+                <td>{{ ingreso.montoAplicado | number: '1.2-2' }}</td>
+              </tr>
+            </tbody>
+            <tfoot>
+              <tr>
+                <td>Total</td>
+                <td>{{ resumenData.totalIngresos.montoReservado | number: '1.2-2' }}</td>
+                <td>{{ resumenData.totalIngresos.montoAplicado | number: '1.2-2' }}</td>
+              </tr>
+            </tfoot>
+          </table>
+        </article>
+
+        <article class="resumen-card">
+          <header>
+            <h3>Egresos</h3>
+            <span class="monto-pill monto-pill--egreso">
+              Reservado: {{ resumenData.totalEgresos.montoReservado | number: '1.2-2' }}
+            </span>
+          </header>
+
+          <p *ngIf="resumenData.egresos.length === 0" class="resumen-card__empty">
+            No hay egresos reservados para este periodo.
+          </p>
+
+          <table *ngIf="resumenData.egresos.length > 0" class="resumen-table">
+            <thead>
+              <tr>
+                <th>Categoría</th>
+                <th>Reservado</th>
+                <th>Aplicado</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr *ngFor="let egreso of resumenData.egresos; trackBy: trackByCategoriaId">
+                <td>
+                  <div class="categoria-nombre">{{ egreso.categoriaNombre }}</div>
+                  <small *ngIf="egreso.orden != null" class="categoria-orden">Orden {{ egreso.orden }}</small>
+                </td>
+                <td>{{ egreso.montoReservado | number: '1.2-2' }}</td>
+                <td>{{ egreso.montoAplicado | number: '1.2-2' }}</td>
+              </tr>
+            </tbody>
+            <tfoot>
+              <tr>
+                <td>Total</td>
+                <td>{{ resumenData.totalEgresos.montoReservado | number: '1.2-2' }}</td>
+                <td>{{ resumenData.totalEgresos.montoAplicado | number: '1.2-2' }}</td>
+              </tr>
+            </tfoot>
+          </table>
+        </article>
+      </section>
+
+      <section class="resumen-totales">
+        <h3>Total general</h3>
+        <div class="totales-grid">
+          <div class="total-card">
+            <span class="total-label">Monto reservado</span>
+            <strong>{{ resumenData.totalGeneral.montoReservado | number: '1.2-2' }}</strong>
+          </div>
+          <div class="total-card">
+            <span class="total-label">Monto aplicado</span>
+            <strong>{{ resumenData.totalGeneral.montoAplicado | number: '1.2-2' }}</strong>
+          </div>
+        </div>
+      </section>
+    </ng-container>
+  </ng-container>
+
+  <ng-template #emptyState>
+    <p class="resumen-panel__empty">No hay información de reservas para este periodo.</p>
+  </ng-template>
+</section>

--- a/fnanz-app/src/app/features/periodos-financieros/reservas-resumen/reservas-resumen.component.scss
+++ b/fnanz-app/src/app/features/periodos-financieros/reservas-resumen/reservas-resumen.component.scss
@@ -1,0 +1,151 @@
+.resumen-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.resumen-panel__header {
+  align-items: center;
+  display: flex;
+  gap: 1rem;
+  justify-content: space-between;
+  flex-wrap: wrap;
+}
+
+.resumen-panel__subtitle {
+  color: #6b7280;
+  margin: 0.25rem 0 0;
+}
+
+.resumen-panel__loading,
+.resumen-panel__error,
+.resumen-panel__empty {
+  border-radius: 0.75rem;
+  margin: 0;
+  padding: 1rem;
+}
+
+.resumen-panel__loading {
+  background-color: #f3f4f6;
+}
+
+.resumen-panel__error {
+  background-color: #fee2e2;
+  color: #991b1b;
+}
+
+.resumen-panel__empty {
+  background-color: #f9fafb;
+}
+
+.resumen-grid {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+}
+
+.resumen-card {
+  background-color: #f9fafb;
+  border-radius: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  padding: 1.5rem;
+}
+
+.resumen-card header {
+  align-items: center;
+  display: flex;
+  justify-content: space-between;
+}
+
+.resumen-card h3 {
+  margin: 0;
+}
+
+.resumen-card__empty {
+  color: #6b7280;
+  margin: 0;
+}
+
+.resumen-table {
+  border-collapse: collapse;
+  width: 100%;
+}
+
+.resumen-table th,
+.resumen-table td {
+  border-bottom: 1px solid #e5e7eb;
+  padding: 0.65rem 0.75rem;
+  text-align: left;
+}
+
+.resumen-table th {
+  color: #6b7280;
+  font-size: 0.85rem;
+  font-weight: 600;
+  text-transform: uppercase;
+}
+
+.resumen-table tfoot td {
+  font-weight: 600;
+}
+
+.categoria-nombre {
+  font-weight: 600;
+}
+
+.categoria-orden {
+  color: #6b7280;
+}
+
+.monto-pill {
+  border-radius: 999px;
+  color: #fff;
+  font-size: 0.75rem;
+  font-weight: 600;
+  padding: 0.35rem 0.75rem;
+}
+
+.monto-pill--ingreso {
+  background-color: #047857;
+}
+
+.monto-pill--egreso {
+  background-color: #b91c1c;
+}
+
+.resumen-totales {
+  background-color: #f3f4f6;
+  border-radius: 1rem;
+  padding: 1.5rem;
+}
+
+.resumen-totales h3 {
+  margin-top: 0;
+}
+
+.totales-grid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  margin-top: 1rem;
+}
+
+.total-card {
+  background-color: #fff;
+  border-radius: 0.85rem;
+  box-shadow: 0 5px 12px rgba(15, 23, 42, 0.08);
+  padding: 1rem 1.25rem;
+}
+
+.total-label {
+  color: #6b7280;
+  display: block;
+  font-size: 0.85rem;
+  margin-bottom: 0.5rem;
+}
+
+.total-card strong {
+  font-size: 1.4rem;
+}

--- a/fnanz-app/src/app/features/periodos-financieros/reservas-resumen/reservas-resumen.component.ts
+++ b/fnanz-app/src/app/features/periodos-financieros/reservas-resumen/reservas-resumen.component.ts
@@ -1,0 +1,84 @@
+import { DecimalPipe, NgFor, NgIf } from '@angular/common';
+import { Component, OnInit, inject, signal } from '@angular/core';
+import { ActivatedRoute, Router, RouterLink } from '@angular/router';
+
+import {
+  GastoReservadoCategoriaResumen,
+  PeriodoFinancieroReservasResumen
+} from '../../../shared/models/periodo-financiero.model';
+import { PeriodoFinancieroService } from '../../../core/services/periodo-financiero.service';
+
+@Component({
+  selector: 'app-periodo-reservas-resumen',
+  standalone: true,
+  imports: [DecimalPipe, NgFor, NgIf, RouterLink],
+  templateUrl: './reservas-resumen.component.html',
+  styleUrls: ['./reservas-resumen.component.scss']
+})
+export class ReservasResumenComponent implements OnInit {
+  private readonly route = inject(ActivatedRoute);
+  private readonly router = inject(Router);
+  private readonly periodoService = inject(PeriodoFinancieroService);
+
+  readonly loading = signal(false);
+  readonly error = signal<string | null>(null);
+  readonly resumen = signal<PeriodoFinancieroReservasResumen | null>(null);
+  readonly periodoNombre = signal<string | null>(null);
+  readonly periodoId = signal<number | null>(null);
+
+  ngOnInit(): void {
+    this.resolvePeriodoNombre();
+
+    this.route.paramMap.subscribe((params) => {
+      const idParam = params.get('id');
+      const id = idParam ? Number(idParam) : NaN;
+
+      if (!idParam || Number.isNaN(id)) {
+        this.error.set('El identificador del periodo no es válido.');
+        this.periodoId.set(null);
+        this.resumen.set(null);
+        return;
+      }
+
+      this.periodoId.set(id);
+      this.loadResumen(id);
+    });
+  }
+
+  trackByCategoriaId = (_: number, categoria: GastoReservadoCategoriaResumen): number =>
+    categoria.categoriaId;
+
+  private resolvePeriodoNombre(): void {
+    const navigation = this.router.getCurrentNavigation();
+    const nombreFromNavigation = navigation?.extras.state?.['periodoNombre'];
+
+    if (typeof nombreFromNavigation === 'string' && nombreFromNavigation.trim()) {
+      this.periodoNombre.set(nombreFromNavigation.trim());
+      return;
+    }
+
+    if (typeof history !== 'undefined') {
+      const nombreFromHistory = (history.state || {})['periodoNombre'];
+      if (typeof nombreFromHistory === 'string' && nombreFromHistory.trim()) {
+        this.periodoNombre.set(nombreFromHistory.trim());
+      }
+    }
+  }
+
+  private loadResumen(id: number): void {
+    this.loading.set(true);
+    this.error.set(null);
+    this.resumen.set(null);
+
+    this.periodoService.getReservasResumen(id).subscribe({
+      next: (data) => {
+        this.resumen.set(data);
+        this.loading.set(false);
+      },
+      error: () => {
+        this.error.set('No se pudo cargar el resumen de reservas.');
+        this.loading.set(false);
+      }
+    });
+  }
+}

--- a/fnanz-app/src/app/shared/models/periodo-financiero.model.ts
+++ b/fnanz-app/src/app/shared/models/periodo-financiero.model.ts
@@ -20,3 +20,25 @@ export type PeriodoFinancieroCreate = {
 };
 
 export type PeriodoFinancieroUpdate = Partial<PeriodoFinancieroCreate>;
+
+export interface GastoReservadoCategoriaResumen {
+  categoriaId: number;
+  categoriaNombre: string;
+  tipo: 'INGRESO' | 'EGRESO';
+  orden?: number | null;
+  montoReservado: number;
+  montoAplicado: number;
+}
+
+export interface GastoReservadoTotales {
+  montoReservado: number;
+  montoAplicado: number;
+}
+
+export interface PeriodoFinancieroReservasResumen {
+  ingresos: GastoReservadoCategoriaResumen[];
+  totalIngresos: GastoReservadoTotales;
+  egresos: GastoReservadoCategoriaResumen[];
+  totalEgresos: GastoReservadoTotales;
+  totalGeneral: GastoReservadoTotales;
+}


### PR DESCRIPTION
## Summary
- add routing, models, and service integration for the reservas resumen endpoint
- create a new standalone screen that displays ingresos, egresos, and totales por categoría for un periodo financiero
- link the resumen screen from the periodos financieros list for quick access

## Testing
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68de9dfa4cb0832fbf0e4f5a1ff0d681