### PR TITLE
feat: filtrar gastos reservados por periodo

### DIFF
--- a/fnanz-app/src/app/core/services/gasto-reservado.service.ts
+++ b/fnanz-app/src/app/core/services/gasto-reservado.service.ts
@@ -36,6 +36,14 @@ export class GastoReservadoService {
       .pipe(map((response) => response.data ?? []));
   }
 
+  listByPeriodo(periodoId: number): Observable<GastoReservado[]> {
+    return this.apiHttp
+      .get<ApiResponse<GastoReservado[]>>(
+        `${this.basePath}/periodo/${periodoId}`
+      )
+      .pipe(map((response) => response.data ?? []));
+  }
+
   create(payload: GastoReservadoCreate): Observable<GastoReservado> {
     return this.apiHttp
       .post<ApiResponse<GastoReservado>>(this.basePath, payload)

--- a/fnanz-app/src/app/core/services/periodo-financiero.service.ts
+++ b/fnanz-app/src/app/core/services/periodo-financiero.service.ts
@@ -4,6 +4,7 @@ import { map, Observable } from 'rxjs';
 import {
   PeriodoFinanciero,
   PeriodoFinancieroCreate,
+  PeriodoFinancieroDropdown,
   PeriodoFinancieroReservasResumen,
   PeriodoFinancieroUpdate
 } from '../../shared/models/periodo-financiero.model';
@@ -34,6 +35,17 @@ export class PeriodoFinancieroService {
 
     return this.apiHttp
       .get<ApiResponse<PeriodoFinanciero[]>>(this.basePath, { params })
+      .pipe(map((response) => response.data ?? []));
+  }
+
+  dropdown(soloAbiertos: boolean): Observable<PeriodoFinancieroDropdown[]> {
+    const params = soloAbiertos ? { soloAbiertos: true } : {};
+
+    return this.apiHttp
+      .get<ApiResponse<PeriodoFinancieroDropdown[]>>(
+        `${this.basePath}/dropdown`,
+        { params }
+      )
       .pipe(map((response) => response.data ?? []));
   }
 

--- a/fnanz-app/src/app/features/gastos-reservados/gastos-reservados.component.html
+++ b/fnanz-app/src/app/features/gastos-reservados/gastos-reservados.component.html
@@ -168,7 +168,9 @@
       </label>
 
       <div class="form-actions">
-        <button type="button" class="ghost-button" (click)="cancelForm()">Cancelar</button>
+        <button type="button" class="ghost-button" (click)="promptCancelForm()" [disabled]="saving()">
+          Cancelar
+        </button>
         <button type="submit" class="primary-button" [disabled]="saving()">
           {{ saving() ? 'Guardando...' : 'Guardar' }}
         </button>
@@ -176,7 +178,10 @@
     </form>
   </section>
 
-  <div class="gasto-grid" *ngIf="!loading() && gastos().length > 0; else emptyState">
+  <div
+    class="gasto-grid"
+    *ngIf="!showForm() && !loading() && gastos().length > 0; else emptyState"
+  >
     <table class="data-table">
       <thead>
         <tr>
@@ -206,8 +211,10 @@
             <span [ngClass]="'estado estado--' + gasto.estado.toLowerCase()">{{ gasto.estado }}</span>
           </td>
           <td>{{ gasto.periodoNombre }}</td>
-          <td>{{ gasto.montoReservado | currency: 'USD':'symbol-narrow':'1.0-0' }}</td>
-          <td>{{ gasto.montoAplicado != null ? (gasto.montoAplicado | currency: 'USD':'symbol-narrow':'1.0-0') : '—' }}</td>
+          <td class="data-table__numeric">{{ gasto.montoReservado | number: '1.2-2' }}</td>
+          <td class="data-table__numeric">
+            {{ gasto.montoAplicado != null ? (gasto.montoAplicado | number: '1.2-2') : '—' }}
+          </td>
           <td class="data-table__actions">
             <button
               type="button"
@@ -261,7 +268,7 @@
   </div>
 
   <ng-template #emptyState>
-    <p class="gasto-panel__empty" *ngIf="!loading()">
+    <p class="gasto-panel__empty" *ngIf="!showForm() && !loading()">
       {{
         selectedPeriodoId() === null
           ? 'Selecciona un periodo financiero para ver los gastos reservados.'
@@ -281,5 +288,15 @@
     [confirmDestructive]="true"
     (cancel)="closeDeleteDialog()"
     (confirm)="confirmDeleteGasto()"
+  ></app-confirm-dialog>
+
+  <app-confirm-dialog
+    [open]="cancelDialogOpen()"
+    [title]="cancelDialogTitle()"
+    [message]="cancelDialogMessage()"
+    confirmLabel="Sí, cancelar"
+    cancelLabel="Seguir editando"
+    (cancel)="closeCancelDialog()"
+    (confirm)="confirmCancelForm()"
   ></app-confirm-dialog>
 </section>

--- a/fnanz-app/src/app/features/gastos-reservados/gastos-reservados.component.html
+++ b/fnanz-app/src/app/features/gastos-reservados/gastos-reservados.component.html
@@ -22,7 +22,7 @@
   <p *ngIf="periodosError()" class="gasto-panel__warning">{{ periodosError() }}</p>
   <p *ngIf="periodosDropdownError()" class="gasto-panel__warning">{{ periodosDropdownError() }}</p>
 
-  <section class="gasto-panel__filters" [class.is-hidden]="showForm()">
+  <section *ngIf="!showForm()" class="gasto-panel__filters">
     <label class="filter-field">
       <span>Periodo financiero</span>
       <select
@@ -47,7 +47,7 @@
     </label>
   </section>
 
-  <p *ngIf="periodosDropdownLoading()" class="gasto-panel__loading" [class.is-hidden]="showForm()">
+  <p *ngIf="periodosDropdownLoading() && !showForm()" class="gasto-panel__loading">
     Cargando periodos financieros...
   </p>
 
@@ -178,7 +178,7 @@
     </form>
   </section>
 
-  <div class="gasto-grid" [class.is-hidden]="showForm()">
+  <div *ngIf="!showForm()" class="gasto-grid">
     <table class="data-table">
       <thead>
         <tr>

--- a/fnanz-app/src/app/features/gastos-reservados/gastos-reservados.component.html
+++ b/fnanz-app/src/app/features/gastos-reservados/gastos-reservados.component.html
@@ -6,7 +6,12 @@
         Administra los compromisos de ingresos o egresos reservados para futuros períodos.
       </p>
     </div>
-    <button type="button" class="primary-button" (click)="startCreate()" [disabled]="loading() || saving()">
+    <button
+      type="button"
+      class="primary-button"
+      (click)="startCreate()"
+      [disabled]="loading() || saving() || selectedPeriodoId() === null"
+    >
       Nuevo gasto reservado
     </button>
   </header>
@@ -22,6 +27,7 @@
       <span>Periodo financiero</span>
       <select
         [disabled]="periodosDropdownLoading() || periodosDropdown().length === 0"
+        [value]="selectedPeriodoId() ?? ''"
         (change)="onPeriodoDropdownChange($any($event.target).value)"
       >
         <option value="">Selecciona un periodo</option>
@@ -85,22 +91,37 @@
         <small *ngIf="getServerError('concepto') as serverError">{{ serverError }}</small>
       </label>
 
-      <label class="form-field" [class.form-field--invalid]="hasControlError('periodoId')">
-        <span>Periodo *</span>
-        <select formControlName="periodoId" [disabled]="periodosLoading() || periodos().length === 0">
-          <option [ngValue]="null" disabled>Seleccione un periodo</option>
-          <option *ngFor="let periodo of periodos()" [ngValue]="periodo.id">
-            {{ periodo.nombre }} ({{ periodo.fechaInicio | date: 'longDate' }} - {{ periodo.fechaFin | date: 'longDate' }})
-          </option>
-        </select>
-        <small *ngIf="form.controls.periodoId.touched && form.controls.periodoId.hasError('required')">
-          El periodo es obligatorio.
-        </small>
-        <small *ngIf="getServerError('periodoId') as serverError">{{ serverError }}</small>
-        <small *ngIf="!periodosLoading() && periodos().length === 0">
-          Debes crear al menos un periodo financiero para asignarlo al gasto.
-        </small>
-      </label>
+      <ng-container *ngIf="selectedGasto(); else periodoSeleccionado">
+        <label class="form-field" [class.form-field--invalid]="hasControlError('periodoId')">
+          <span>Periodo *</span>
+          <select formControlName="periodoId" [disabled]="periodosLoading() || periodos().length === 0">
+            <option [ngValue]="null" disabled>Seleccione un periodo</option>
+            <option *ngFor="let periodo of periodos()" [ngValue]="periodo.id">
+              {{ periodo.nombre }} ({{ periodo.fechaInicio | date: 'longDate' }} -
+              {{ periodo.fechaFin | date: 'longDate' }})
+            </option>
+          </select>
+          <small *ngIf="form.controls.periodoId.touched && form.controls.periodoId.hasError('required')">
+            El periodo es obligatorio.
+          </small>
+          <small *ngIf="getServerError('periodoId') as serverError">{{ serverError }}</small>
+          <small *ngIf="!periodosLoading() && periodos().length === 0">
+            Debes crear al menos un periodo financiero para asignarlo al gasto.
+          </small>
+        </label>
+      </ng-container>
+      <ng-template #periodoSeleccionado>
+        <div class="form-field form-field--static">
+          <span>Periodo *</span>
+          <p class="form-field__readonly" *ngIf="selectedPeriodoDetalle() as periodo; else periodoSinSeleccion">
+            {{ periodo.nombre }} ({{ periodo.fechaInicio | date: 'longDate' }} -
+            {{ periodo.fechaFin | date: 'longDate' }})
+          </p>
+          <ng-template #periodoSinSeleccion>
+            <p class="form-field__readonly">Selecciona un periodo financiero en el filtro superior.</p>
+          </ng-template>
+        </div>
+      </ng-template>
 
       <label class="form-field" [class.form-field--invalid]="hasControlError('estado')">
         <span>Estado *</span>

--- a/fnanz-app/src/app/features/gastos-reservados/gastos-reservados.component.html
+++ b/fnanz-app/src/app/features/gastos-reservados/gastos-reservados.component.html
@@ -22,7 +22,7 @@
   <p *ngIf="periodosError()" class="gasto-panel__warning">{{ periodosError() }}</p>
   <p *ngIf="periodosDropdownError()" class="gasto-panel__warning">{{ periodosDropdownError() }}</p>
 
-  <section class="gasto-panel__filters" *ngIf="!showForm()">
+  <section class="gasto-panel__filters" [class.is-hidden]="showForm()">
     <label class="filter-field">
       <span>Periodo financiero</span>
       <select
@@ -47,7 +47,7 @@
     </label>
   </section>
 
-  <p *ngIf="periodosDropdownLoading()" class="gasto-panel__loading">
+  <p *ngIf="periodosDropdownLoading()" class="gasto-panel__loading" [class.is-hidden]="showForm()">
     Cargando periodos financieros...
   </p>
 
@@ -178,7 +178,7 @@
     </form>
   </section>
 
-  <div class="gasto-grid" *ngIf="!showForm()">
+  <div class="gasto-grid" [class.is-hidden]="showForm()">
     <table class="data-table">
       <thead>
         <tr>

--- a/fnanz-app/src/app/features/gastos-reservados/gastos-reservados.component.html
+++ b/fnanz-app/src/app/features/gastos-reservados/gastos-reservados.component.html
@@ -193,93 +193,88 @@
         </tr>
       </thead>
       <tbody>
-        <ng-container *ngIf="gastos().length > 0; else emptyRows">
-          <tr *ngFor="let gasto of gastos(); trackBy: trackByGastoId">
-            <td>
-              <div class="gasto-name">{{ gasto.concepto }}</div>
-              <small class="gasto-meta">Actualizado {{ gasto.actualizadoEn | date: 'short' }}</small>
-            </td>
-            <td>
-              <span class="tipo-pill" [ngClass]="gasto.tipo === 'INGRESO' ? 'tipo-pill--ingreso' : 'tipo-pill--egreso'">
-                {{ gasto.tipo }}
-              </span>
-            </td>
-            <td>{{ gasto.categoriaNombre }}</td>
-            <td>
-              <span [ngClass]="'estado estado--' + gasto.estado.toLowerCase()">{{ gasto.estado }}</span>
-            </td>
-            <td>{{ gasto.periodoNombre }}</td>
-            <td class="data-table__numeric">{{ formatAccounting(gasto.montoReservado) }}</td>
-            <td class="data-table__numeric">{{ formatAccounting(gasto.montoAplicado) }}</td>
-            <td class="data-table__actions">
-              <button
-                type="button"
-                class="ghost-button icon-button"
-                (click)="startEdit(gasto)"
-                [disabled]="loading() || saving()"
-                [attr.aria-label]="'Editar gasto reservado: ' + gasto.concepto"
-                [attr.title]="'Editar gasto reservado'"
+        <tr *ngIf="gastos().length === 0">
+          <td class="data-table__empty" colspan="8">
+            <ng-container *ngIf="loading(); else emptyMessage">
+              Cargando información...
+            </ng-container>
+            <ng-template #emptyMessage>
+              {{
+                selectedPeriodoId() === null
+                  ? 'Selecciona un periodo financiero para ver los gastos reservados.'
+                  : 'No hay gastos reservados registrados para el periodo seleccionado.'
+              }}
+            </ng-template>
+          </td>
+        </tr>
+        <tr *ngFor="let gasto of gastos(); trackBy: trackByGastoId">
+          <td>
+            <div class="gasto-name">{{ gasto.concepto }}</div>
+            <small class="gasto-meta">Actualizado {{ gasto.actualizadoEn | date: 'short' }}</small>
+          </td>
+          <td>
+            <span class="tipo-pill" [ngClass]="gasto.tipo === 'INGRESO' ? 'tipo-pill--ingreso' : 'tipo-pill--egreso'">
+              {{ gasto.tipo }}
+            </span>
+          </td>
+          <td>{{ gasto.categoriaNombre }}</td>
+          <td>
+            <span [ngClass]="'estado estado--' + gasto.estado.toLowerCase()">{{ gasto.estado }}</span>
+          </td>
+          <td>{{ gasto.periodoNombre }}</td>
+          <td class="data-table__numeric">{{ formatAccounting(gasto.montoReservado) }}</td>
+          <td class="data-table__numeric">{{ formatAccounting(gasto.montoAplicado) }}</td>
+          <td class="data-table__actions">
+            <button
+              type="button"
+              class="ghost-button icon-button"
+              (click)="startEdit(gasto)"
+              [disabled]="loading() || saving()"
+              [attr.aria-label]="'Editar gasto reservado: ' + gasto.concepto"
+              [attr.title]="'Editar gasto reservado'"
+            >
+              <svg
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="1.5"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                aria-hidden="true"
               >
-                <svg
-                  viewBox="0 0 24 24"
-                  fill="none"
-                  stroke="currentColor"
-                  stroke-width="1.5"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  aria-hidden="true"
-                >
-                  <path d="M12 20h9" />
-                  <path d="M16.5 3.5a2.121 2.121 0 1 1 3 3L7 19l-4 1 1-4L16.5 3.5z" />
-                </svg>
-              </button>
-              <button
-                type="button"
-                class="danger-button icon-button"
-                (click)="promptDelete(gasto)"
-                [disabled]="loading() || saving()"
-                [attr.aria-label]="'Eliminar gasto reservado: ' + gasto.concepto"
-                [attr.title]="'Eliminar gasto reservado'"
+                <path d="M12 20h9" />
+                <path d="M16.5 3.5a2.121 2.121 0 1 1 3 3L7 19l-4 1 1-4L16.5 3.5z" />
+              </svg>
+            </button>
+            <button
+              type="button"
+              class="danger-button icon-button"
+              (click)="promptDelete(gasto)"
+              [disabled]="loading() || saving()"
+              [attr.aria-label]="'Eliminar gasto reservado: ' + gasto.concepto"
+              [attr.title]="'Eliminar gasto reservado'"
+            >
+              <svg
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="1.5"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                aria-hidden="true"
               >
-                <svg
-                  viewBox="0 0 24 24"
-                  fill="none"
-                  stroke="currentColor"
-                  stroke-width="1.5"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  aria-hidden="true"
-                >
-                  <polyline points="3 6 5 6 21 6" />
-                  <path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6" />
-                  <path d="M10 11v6" />
-                  <path d="M14 11v6" />
-                  <path d="M9 6V4a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v2" />
-                </svg>
-              </button>
-            </td>
-          </tr>
-        </ng-container>
+                <polyline points="3 6 5 6 21 6" />
+                <path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6" />
+                <path d="M10 11v6" />
+                <path d="M14 11v6" />
+                <path d="M9 6V4a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v2" />
+              </svg>
+            </button>
+          </td>
+        </tr>
       </tbody>
     </table>
   </div>
-
-  <ng-template #emptyRows>
-    <tr>
-      <td class="data-table__empty" colspan="8">
-        <ng-container *ngIf="loading(); else emptyMessage">
-          Cargando información...
-        </ng-container>
-        <ng-template #emptyMessage>
-          {{
-            selectedPeriodoId() === null
-              ? 'Selecciona un periodo financiero para ver los gastos reservados.'
-              : 'No hay gastos reservados registrados para el periodo seleccionado.'
-          }}
-        </ng-template>
-      </td>
-    </tr>
-  </ng-template>
 
   <app-confirm-dialog
     [open]="gastoPendingDelete() !== null"

--- a/fnanz-app/src/app/features/gastos-reservados/gastos-reservados.component.html
+++ b/fnanz-app/src/app/features/gastos-reservados/gastos-reservados.component.html
@@ -15,6 +15,35 @@
   <p *ngIf="error() && !loading()" class="gasto-panel__error">{{ error() }}</p>
   <p *ngIf="categoriasError()" class="gasto-panel__warning">{{ categoriasError() }}</p>
   <p *ngIf="periodosError()" class="gasto-panel__warning">{{ periodosError() }}</p>
+  <p *ngIf="periodosDropdownError()" class="gasto-panel__warning">{{ periodosDropdownError() }}</p>
+
+  <section class="gasto-panel__filters">
+    <label class="filter-field">
+      <span>Periodo financiero</span>
+      <select
+        [disabled]="periodosDropdownLoading() || periodosDropdown().length === 0"
+        (change)="onPeriodoDropdownChange($any($event.target).value)"
+      >
+        <option value="">Selecciona un periodo</option>
+        <option *ngFor="let periodo of periodosDropdown()" [value]="periodo.id">
+          {{ periodo.nombre }}
+        </option>
+      </select>
+    </label>
+
+    <label class="filter-checkbox">
+      <input
+        type="checkbox"
+        [checked]="includePeriodosCerrados()"
+        (change)="onIncludePeriodosCerradosChange($any($event.target).checked)"
+      />
+      <span>Incluir periodos cerrados</span>
+    </label>
+  </section>
+
+  <p *ngIf="periodosDropdownLoading()" class="gasto-panel__loading">
+    Cargando periodos financieros...
+  </p>
 
   <section *ngIf="showForm()" class="gasto-form">
     <h3>{{ formTitle() }}</h3>
@@ -212,7 +241,11 @@
 
   <ng-template #emptyState>
     <p class="gasto-panel__empty" *ngIf="!loading()">
-      No hay gastos reservados registrados. Registra uno nuevo para comenzar.
+      {{
+        selectedPeriodoId() === null
+          ? 'Selecciona un periodo financiero para ver los gastos reservados.'
+          : 'No hay gastos reservados registrados para el periodo seleccionado.'
+      }}
     </p>
   </ng-template>
 

--- a/fnanz-app/src/app/features/gastos-reservados/gastos-reservados.component.html
+++ b/fnanz-app/src/app/features/gastos-reservados/gastos-reservados.component.html
@@ -22,7 +22,7 @@
   <p *ngIf="periodosError()" class="gasto-panel__warning">{{ periodosError() }}</p>
   <p *ngIf="periodosDropdownError()" class="gasto-panel__warning">{{ periodosDropdownError() }}</p>
 
-  <section class="gasto-panel__filters">
+  <section class="gasto-panel__filters" *ngIf="!showForm()">
     <label class="filter-field">
       <span>Periodo financiero</span>
       <select
@@ -211,10 +211,8 @@
             <span [ngClass]="'estado estado--' + gasto.estado.toLowerCase()">{{ gasto.estado }}</span>
           </td>
           <td>{{ gasto.periodoNombre }}</td>
-          <td class="data-table__numeric">{{ gasto.montoReservado | number: '1.2-2' }}</td>
-          <td class="data-table__numeric">
-            {{ gasto.montoAplicado != null ? (gasto.montoAplicado | number: '1.2-2') : '—' }}
-          </td>
+          <td class="data-table__numeric">{{ formatAccounting(gasto.montoReservado) }}</td>
+          <td class="data-table__numeric">{{ formatAccounting(gasto.montoAplicado) }}</td>
           <td class="data-table__actions">
             <button
               type="button"

--- a/fnanz-app/src/app/features/gastos-reservados/gastos-reservados.component.html
+++ b/fnanz-app/src/app/features/gastos-reservados/gastos-reservados.component.html
@@ -178,10 +178,7 @@
     </form>
   </section>
 
-  <div
-    class="gasto-grid"
-    *ngIf="!showForm() && !loading() && gastos().length > 0; else emptyState"
-  >
+  <div class="gasto-grid" *ngIf="!showForm()">
     <table class="data-table">
       <thead>
         <tr>
@@ -196,83 +193,92 @@
         </tr>
       </thead>
       <tbody>
-        <tr *ngFor="let gasto of gastos(); trackBy: trackByGastoId">
-          <td>
-            <div class="gasto-name">{{ gasto.concepto }}</div>
-            <small class="gasto-meta">Actualizado {{ gasto.actualizadoEn | date: 'short' }}</small>
-          </td>
-          <td>
-            <span class="tipo-pill" [ngClass]="gasto.tipo === 'INGRESO' ? 'tipo-pill--ingreso' : 'tipo-pill--egreso'">
-              {{ gasto.tipo }}
-            </span>
-          </td>
-          <td>{{ gasto.categoriaNombre }}</td>
-          <td>
-            <span [ngClass]="'estado estado--' + gasto.estado.toLowerCase()">{{ gasto.estado }}</span>
-          </td>
-          <td>{{ gasto.periodoNombre }}</td>
-          <td class="data-table__numeric">{{ formatAccounting(gasto.montoReservado) }}</td>
-          <td class="data-table__numeric">{{ formatAccounting(gasto.montoAplicado) }}</td>
-          <td class="data-table__actions">
-            <button
-              type="button"
-              class="ghost-button icon-button"
-              (click)="startEdit(gasto)"
-              [disabled]="loading() || saving()"
-              [attr.aria-label]="'Editar gasto reservado: ' + gasto.concepto"
-              [attr.title]="'Editar gasto reservado'"
-            >
-              <svg
-                viewBox="0 0 24 24"
-                fill="none"
-                stroke="currentColor"
-                stroke-width="1.5"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                aria-hidden="true"
+        <ng-container *ngIf="gastos().length > 0; else emptyRows">
+          <tr *ngFor="let gasto of gastos(); trackBy: trackByGastoId">
+            <td>
+              <div class="gasto-name">{{ gasto.concepto }}</div>
+              <small class="gasto-meta">Actualizado {{ gasto.actualizadoEn | date: 'short' }}</small>
+            </td>
+            <td>
+              <span class="tipo-pill" [ngClass]="gasto.tipo === 'INGRESO' ? 'tipo-pill--ingreso' : 'tipo-pill--egreso'">
+                {{ gasto.tipo }}
+              </span>
+            </td>
+            <td>{{ gasto.categoriaNombre }}</td>
+            <td>
+              <span [ngClass]="'estado estado--' + gasto.estado.toLowerCase()">{{ gasto.estado }}</span>
+            </td>
+            <td>{{ gasto.periodoNombre }}</td>
+            <td class="data-table__numeric">{{ formatAccounting(gasto.montoReservado) }}</td>
+            <td class="data-table__numeric">{{ formatAccounting(gasto.montoAplicado) }}</td>
+            <td class="data-table__actions">
+              <button
+                type="button"
+                class="ghost-button icon-button"
+                (click)="startEdit(gasto)"
+                [disabled]="loading() || saving()"
+                [attr.aria-label]="'Editar gasto reservado: ' + gasto.concepto"
+                [attr.title]="'Editar gasto reservado'"
               >
-                <path d="M12 20h9" />
-                <path d="M16.5 3.5a2.121 2.121 0 1 1 3 3L7 19l-4 1 1-4L16.5 3.5z" />
-              </svg>
-            </button>
-            <button
-              type="button"
-              class="danger-button icon-button"
-              (click)="promptDelete(gasto)"
-              [disabled]="loading() || saving()"
-              [attr.aria-label]="'Eliminar gasto reservado: ' + gasto.concepto"
-              [attr.title]="'Eliminar gasto reservado'"
-            >
-              <svg
-                viewBox="0 0 24 24"
-                fill="none"
-                stroke="currentColor"
-                stroke-width="1.5"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                aria-hidden="true"
+                <svg
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="1.5"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  aria-hidden="true"
+                >
+                  <path d="M12 20h9" />
+                  <path d="M16.5 3.5a2.121 2.121 0 1 1 3 3L7 19l-4 1 1-4L16.5 3.5z" />
+                </svg>
+              </button>
+              <button
+                type="button"
+                class="danger-button icon-button"
+                (click)="promptDelete(gasto)"
+                [disabled]="loading() || saving()"
+                [attr.aria-label]="'Eliminar gasto reservado: ' + gasto.concepto"
+                [attr.title]="'Eliminar gasto reservado'"
               >
-                <polyline points="3 6 5 6 21 6" />
-                <path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6" />
-                <path d="M10 11v6" />
-                <path d="M14 11v6" />
-                <path d="M9 6V4a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v2" />
-              </svg>
-            </button>
-          </td>
-        </tr>
+                <svg
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="1.5"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  aria-hidden="true"
+                >
+                  <polyline points="3 6 5 6 21 6" />
+                  <path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6" />
+                  <path d="M10 11v6" />
+                  <path d="M14 11v6" />
+                  <path d="M9 6V4a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v2" />
+                </svg>
+              </button>
+            </td>
+          </tr>
+        </ng-container>
       </tbody>
     </table>
   </div>
 
-  <ng-template #emptyState>
-    <p class="gasto-panel__empty" *ngIf="!showForm() && !loading()">
-      {{
-        selectedPeriodoId() === null
-          ? 'Selecciona un periodo financiero para ver los gastos reservados.'
-          : 'No hay gastos reservados registrados para el periodo seleccionado.'
-      }}
-    </p>
+  <ng-template #emptyRows>
+    <tr>
+      <td class="data-table__empty" colspan="8">
+        <ng-container *ngIf="loading(); else emptyMessage">
+          Cargando información...
+        </ng-container>
+        <ng-template #emptyMessage>
+          {{
+            selectedPeriodoId() === null
+              ? 'Selecciona un periodo financiero para ver los gastos reservados.'
+              : 'No hay gastos reservados registrados para el periodo seleccionado.'
+          }}
+        </ng-template>
+      </td>
+    </tr>
   </ng-template>
 
   <app-confirm-dialog

--- a/fnanz-app/src/app/features/gastos-reservados/gastos-reservados.component.scss
+++ b/fnanz-app/src/app/features/gastos-reservados/gastos-reservados.component.scss
@@ -17,6 +17,10 @@
   margin: 0.25rem 0 0;
 }
 
+.is-hidden {
+  display: none !important;
+}
+
 .gasto-panel__filters {
   align-items: flex-end;
   display: flex;

--- a/fnanz-app/src/app/features/gastos-reservados/gastos-reservados.component.scss
+++ b/fnanz-app/src/app/features/gastos-reservados/gastos-reservados.component.scss
@@ -17,6 +17,44 @@
   margin: 0.25rem 0 0;
 }
 
+.gasto-panel__filters {
+  align-items: flex-end;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+}
+
+.filter-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.filter-field span {
+  font-weight: 600;
+}
+
+.filter-field select {
+  border: 1px solid #d1d5db;
+  border-radius: 0.65rem;
+  font: inherit;
+  padding: 0.6rem 0.75rem;
+  min-width: 200px;
+}
+
+.filter-checkbox {
+  align-items: center;
+  display: inline-flex;
+  gap: 0.5rem;
+  font-weight: 500;
+}
+
+.filter-checkbox input[type='checkbox'] {
+  accent-color: var(--fnanz-primary);
+  height: 1.1rem;
+  width: 1.1rem;
+}
+
 .primary-button,
 .ghost-button,
 .danger-button {

--- a/fnanz-app/src/app/features/gastos-reservados/gastos-reservados.component.scss
+++ b/fnanz-app/src/app/features/gastos-reservados/gastos-reservados.component.scss
@@ -233,6 +233,13 @@
   font-variant-numeric: tabular-nums;
 }
 
+.data-table__empty {
+  color: #6b7280;
+  font-style: italic;
+  padding: 2rem 1rem;
+  text-align: center;
+}
+
 .gasto-name {
   font-weight: 600;
 }

--- a/fnanz-app/src/app/features/gastos-reservados/gastos-reservados.component.scss
+++ b/fnanz-app/src/app/features/gastos-reservados/gastos-reservados.component.scss
@@ -17,10 +17,6 @@
   margin: 0.25rem 0 0;
 }
 
-.is-hidden {
-  display: none !important;
-}
-
 .gasto-panel__filters {
   align-items: flex-end;
   display: flex;

--- a/fnanz-app/src/app/features/gastos-reservados/gastos-reservados.component.scss
+++ b/fnanz-app/src/app/features/gastos-reservados/gastos-reservados.component.scss
@@ -228,6 +228,11 @@
   white-space: nowrap;
 }
 
+.data-table__numeric {
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+}
+
 .gasto-name {
   font-weight: 600;
 }
@@ -290,6 +295,10 @@
   .data-table td {
     border: none;
     padding: 0;
+  }
+
+  .data-table__numeric {
+    text-align: right;
   }
 
   .data-table__actions {

--- a/fnanz-app/src/app/features/gastos-reservados/gastos-reservados.component.scss
+++ b/fnanz-app/src/app/features/gastos-reservados/gastos-reservados.component.scss
@@ -177,6 +177,20 @@
   grid-column: 1 / -1;
 }
 
+.form-field--static {
+  grid-column: 1 / -1;
+}
+
+.form-field__readonly {
+  background-color: #fff;
+  border: 1px dashed #d1d5db;
+  border-radius: 0.65rem;
+  color: #374151;
+  font-weight: 500;
+  margin: 0;
+  padding: 0.6rem 0.75rem;
+}
+
 .form-actions {
   align-items: center;
   display: flex;

--- a/fnanz-app/src/app/features/gastos-reservados/gastos-reservados.component.ts
+++ b/fnanz-app/src/app/features/gastos-reservados/gastos-reservados.component.ts
@@ -1,4 +1,4 @@
-import { CurrencyPipe, DatePipe, DecimalPipe, NgClass, NgFor, NgIf } from '@angular/common';
+import { DatePipe, DecimalPipe, NgClass, NgFor, NgIf } from '@angular/common';
 import { Component, OnInit, computed, inject, signal } from '@angular/core';
 import { FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
 
@@ -21,7 +21,6 @@ import { ConfirmDialogComponent } from '../../shared/components/confirm-dialog/c
   standalone: true,
   imports: [
     ConfirmDialogComponent,
-    CurrencyPipe,
     DatePipe,
     DecimalPipe,
     NgClass,
@@ -37,6 +36,7 @@ export class GastosReservadosComponent implements OnInit {
   private readonly categoriaService = inject(CategoriaFinancieraService);
   private readonly periodoService = inject(PeriodoFinancieroService);
   private readonly formBuilder = inject(FormBuilder);
+  private readonly decimalPipe = inject(DecimalPipe);
 
   readonly gastos = signal<GastoReservado[]>([]);
   readonly categorias = signal<CategoriaFinanciera[]>([]);
@@ -460,5 +460,17 @@ export class GastosReservadosComponent implements OnInit {
         this.periodosDropdownLoading.set(false);
       }
     });
+  }
+
+  formatAccounting(value: number | null | undefined): string {
+    if (value === null || value === undefined) {
+      return '—';
+    }
+
+    const absoluteValue = Math.abs(value);
+    const formattedAbsolute =
+      this.decimalPipe.transform(absoluteValue, '1.0-0') ?? absoluteValue.toString();
+
+    return value < 0 ? `(${formattedAbsolute})` : formattedAbsolute;
   }
 }

--- a/fnanz-app/src/app/features/gastos-reservados/gastos-reservados.component.ts
+++ b/fnanz-app/src/app/features/gastos-reservados/gastos-reservados.component.ts
@@ -56,6 +56,7 @@ export class GastosReservadosComponent implements OnInit {
   readonly showForm = signal(false);
   readonly selectedPeriodoId = signal<number | null>(null);
   readonly includePeriodosCerrados = signal(false);
+  readonly cancelDialogOpen = signal(false);
   readonly tipoOptions: GastoReservado['tipo'][] = ['INGRESO', 'EGRESO'];
   readonly estadoOptions: GastoReservado['estado'][] = [
     'RESERVADO',
@@ -90,6 +91,16 @@ export class GastosReservadosComponent implements OnInit {
     this.selectedGasto()
       ? `Editar gasto reservado: ${this.selectedGasto()!.concepto}`
       : 'Nuevo gasto reservado'
+  );
+
+  readonly cancelDialogTitle = computed(() =>
+    this.selectedGasto() ? 'Cancelar edición' : 'Cancelar creación'
+  );
+
+  readonly cancelDialogMessage = computed(() =>
+    this.selectedGasto()
+      ? '¿Deseas cancelar la edición del gasto reservado? Los cambios no guardados se perderán.'
+      : '¿Deseas cancelar la creación del gasto reservado? Los cambios no guardados se perderán.'
   );
 
   readonly deleteMessage = computed(() => {
@@ -243,11 +254,21 @@ export class GastosReservadosComponent implements OnInit {
     this.showForm.set(true);
   }
 
-  cancelForm(): void {
-    this.form.reset();
-    this.form.controls.periodoId.enable({ emitEvent: false });
-    this.showForm.set(false);
-    this.selectedGasto.set(null);
+  promptCancelForm(): void {
+    if (this.saving()) {
+      return;
+    }
+
+    this.cancelDialogOpen.set(true);
+  }
+
+  closeCancelDialog(): void {
+    this.cancelDialogOpen.set(false);
+  }
+
+  confirmCancelForm(): void {
+    this.resetFormState();
+    this.cancelDialogOpen.set(false);
   }
 
   submitForm(): void {
@@ -399,6 +420,13 @@ export class GastosReservadosComponent implements OnInit {
     });
 
     return applied;
+  }
+
+  private resetFormState(): void {
+    this.form.reset();
+    this.form.controls.periodoId.enable({ emitEvent: false });
+    this.showForm.set(false);
+    this.selectedGasto.set(null);
   }
 
   private loadPeriodosDropdown(): void {

--- a/fnanz-app/src/app/features/gastos-reservados/gastos-reservados.component.ts
+++ b/fnanz-app/src/app/features/gastos-reservados/gastos-reservados.component.ts
@@ -1,4 +1,4 @@
-import { CurrencyPipe, DatePipe, NgClass, NgFor, NgIf } from '@angular/common';
+import { CurrencyPipe, DatePipe, DecimalPipe, NgClass, NgFor, NgIf } from '@angular/common';
 import { Component, OnInit, computed, inject, signal } from '@angular/core';
 import { FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
 
@@ -23,6 +23,7 @@ import { ConfirmDialogComponent } from '../../shared/components/confirm-dialog/c
     ConfirmDialogComponent,
     CurrencyPipe,
     DatePipe,
+    DecimalPipe,
     NgClass,
     NgFor,
     NgIf,

--- a/fnanz-app/src/app/features/gastos-reservados/gastos-reservados.component.ts
+++ b/fnanz-app/src/app/features/gastos-reservados/gastos-reservados.component.ts
@@ -28,6 +28,7 @@ import { ConfirmDialogComponent } from '../../shared/components/confirm-dialog/c
     NgIf,
     ReactiveFormsModule,
   ],
+  providers: [DecimalPipe],
   templateUrl: './gastos-reservados.component.html',
   styleUrls: ['./gastos-reservados.component.scss']
 })

--- a/fnanz-app/src/app/shared/models/periodo-financiero.model.ts
+++ b/fnanz-app/src/app/shared/models/periodo-financiero.model.ts
@@ -21,6 +21,11 @@ export type PeriodoFinancieroCreate = {
 
 export type PeriodoFinancieroUpdate = Partial<PeriodoFinancieroCreate>;
 
+export interface PeriodoFinancieroDropdown {
+  id: number;
+  nombre: string;
+}
+
 export interface GastoReservadoCategoriaResumen {
   categoriaId: number;
   categoriaNombre: string;


### PR DESCRIPTION
## Summary
- agrega el filtro de periodo financiero con opción para incluir periodos cerrados en la grilla de gastos reservados
- consume los nuevos servicios para obtener periodos del dropdown y los gastos reservados filtrados por periodo
- ajusta estilos para los controles del filtro y mantiene la grilla vacía hasta seleccionar un periodo

## Testing
- `npm run test -- --watch=false` *(falla: Chrome no está disponible en el entorno de CI)*

------
https://chatgpt.com/codex/tasks/task_e_68e197e33158832fadc5eceb7b6c2dd1