### PR TITLE
Persist applied budget items via apply endpoint

### DIFF
--- a/fnanz-app/src/app/core/services/partida-presupuestaria.service.ts
+++ b/fnanz-app/src/app/core/services/partida-presupuestaria.service.ts
@@ -3,6 +3,7 @@ import { map, Observable } from 'rxjs';
 
 import {
   PartidaPresupuestaria,
+  PartidaPresupuestariaApplyPayload,
   PartidaPresupuestariaCreate,
   PartidaPresupuestariaUpdate
 } from '../../shared/models/partida-presupuestaria.model';
@@ -65,6 +66,15 @@ export class PartidaPresupuestariaService {
   ): Observable<PartidaPresupuestaria> {
     return this.apiHttp
       .patch<ApiResponse<PartidaPresupuestaria>>(`${this.basePath}/${id}`, payload)
+      .pipe(map((response) => response.data));
+  }
+
+  apply(
+    id: number,
+    payload: PartidaPresupuestariaApplyPayload
+  ): Observable<PartidaPresupuestaria> {
+    return this.apiHttp
+      .patch<ApiResponse<PartidaPresupuestaria>>(`${this.basePath}/${id}/aplicar`, payload)
       .pipe(map((response) => response.data));
   }
 

--- a/fnanz-app/src/app/features/partidas-presupuestarias/partidas-presupuestarias.component.ts
+++ b/fnanz-app/src/app/features/partidas-presupuestarias/partidas-presupuestarias.component.ts
@@ -397,9 +397,8 @@ export class PartidasPresupuestariasComponent implements OnInit {
     this.applyingMontoError.set(null);
 
     this.partidaService
-      .update(partida.id, {
-        montoAplicado: Number(montoAplicado),
-        estado: 'APLICADO'
+      .apply(partida.id, {
+        montoAplicado: Number(montoAplicado)
       })
       .subscribe({
         next: (updatedPartida) => {

--- a/fnanz-app/src/app/shared/models/partida-presupuestaria.model.ts
+++ b/fnanz-app/src/app/shared/models/partida-presupuestaria.model.ts
@@ -28,3 +28,7 @@ export type PartidaPresupuestariaCreate = {
 };
 
 export type PartidaPresupuestariaUpdate = Partial<PartidaPresupuestariaCreate>;
+
+export interface PartidaPresupuestariaApplyPayload {
+  montoAplicado: number;
+}


### PR DESCRIPTION
## Summary
- add a dedicated payload type and service method for applying partidas presupuestarias
- update the apply monto flow to call the /api/partidas-presupuestarias/{id}/aplicar endpoint and reset the UI when it succeeds

## Testing
- not run (no automated scripts provided)


------
https://chatgpt.com/codex/tasks/task_e_68e2b94bab24832f8e23175b749a732c