### PR TITLE
Fix layout shell imports with shared path aliases

### DIFF
--- a/fnanz-app/src/app/app.component.ts
+++ b/fnanz-app/src/app/app.component.ts
@@ -1,8 +1,8 @@
 import { ChangeDetectionStrategy, Component, inject, signal } from '@angular/core';
 
-import { EnvironmentService } from './core/services/environment.service';
-import { LayoutShellComponent } from './shared/components/layout/layout-shell/layout-shell.component';
-import { NavigationLink } from './shared/models/navigation-link.model';
+import { EnvironmentService } from '@core/services/environment.service';
+import { LayoutShellComponent } from '@shared/components/layout/layout-shell/layout-shell.component';
+import type { NavigationLink } from '@shared/models/navigation-link.model';
 
 @Component({
   selector: 'app-root',

--- a/fnanz-app/tsconfig.json
+++ b/fnanz-app/tsconfig.json
@@ -18,6 +18,18 @@
     "target": "es2022",
     "module": "es2022",
     "useDefineForClassFields": false,
+    "baseUrl": "./src",
+    "paths": {
+      "@app/*": [
+        "app/*"
+      ],
+      "@core/*": [
+        "app/core/*"
+      ],
+      "@shared/*": [
+        "app/shared/*"
+      ]
+    },
     "lib": [
       "es2022",
       "dom"


### PR DESCRIPTION
## Summary
- configure TypeScript path aliases for the app, core, and shared directories
- update the app component to consume the layout shell and navigation model via the new aliases

## Testing
- npm install *(fails: 403 Forbidden retrieving undici-types)*

------
https://chatgpt.com/codex/tasks/task_e_68ea6167a1d8832fb0309a23a1de7cb8