### PR TITLE
Align budget grid with theme table styling

### DIFF
--- a/fnanz-app/src/app/features/categorias-financieras/categorias-financieras.component.html
+++ b/fnanz-app/src/app/features/categorias-financieras/categorias-financieras.component.html
@@ -15,14 +15,14 @@
     <div *ngIf="loading()" class="alert alert-info mt-3 mb-0" role="status">Cargando información...</div>
     <div *ngIf="error() && !loading()" class="alert alert-danger mt-3 mb-0" role="alert">{{ error() }}</div>
 
-    <section *ngIf="showForm()" class="categoria-form card border-0 shadow-sm mt-4">
-      <div class="card-body">
-        <form [formGroup]="form" (ngSubmit)="submitForm()" novalidate>
-          <fieldset class="categoria-form__fieldset">
-            <legend class="categoria-form__legend">{{ formTitle() }}</legend>
-
-          <div class="row g-4">
-            <div class="col-12 col-md-6 col-lg-3">
+    <section *ngIf="showForm()" class="categoria-form-wrapper mt-4">
+      <div class="card border-dark mb-3 categoria-form-card">
+        <div class="card-header">
+          <h5 class="mb-0">{{ formTitle() }}</h5>
+        </div>
+        <div class="card-body">
+          <form [formGroup]="form" (ngSubmit)="submitForm()" novalidate>
+            <div class="mb-3">
               <label for="categoriaNombre" class="form-label fw-semibold">Nombre</label>
               <input
                 id="categoriaNombre"
@@ -40,7 +40,7 @@
               <div class="invalid-feedback" *ngIf="getServerError('nombre') as serverError">{{ serverError }}</div>
             </div>
 
-            <div class="col-12 col-md-6 col-lg-3">
+            <div class="mb-3">
               <label for="categoriaTipo" class="form-label fw-semibold">Tipo</label>
               <select
                 id="categoriaTipo"
@@ -53,7 +53,7 @@
               <div class="invalid-feedback" *ngIf="getServerError('tipo') as serverError">{{ serverError }}</div>
             </div>
 
-            <div class="col-12 col-md-6 col-lg-3">
+            <div class="mb-3">
               <label class="form-label d-block" for="categoriaActiva">Estado</label>
               <div class="form-check form-switch">
                 <input
@@ -69,7 +69,7 @@
               <div class="invalid-feedback d-block" *ngIf="getServerError('activo') as serverError">{{ serverError }}</div>
             </div>
 
-            <div class="col-12 col-md-6 col-lg-3">
+            <div class="mb-3">
               <label for="categoriaOrden" class="form-label">Orden</label>
               <input
                 id="categoriaOrden"
@@ -81,7 +81,7 @@
               <div class="invalid-feedback" *ngIf="getServerError('orden') as serverError">{{ serverError }}</div>
             </div>
 
-            <div class="col-12">
+            <div class="mb-4">
               <label for="categoriaDescripcion" class="form-label">Descripción</label>
               <textarea
                 id="categoriaDescripcion"
@@ -92,18 +92,17 @@
               ></textarea>
               <div class="invalid-feedback" *ngIf="getServerError('descripcion') as serverError">{{ serverError }}</div>
             </div>
-          </div>
 
-          <div class="d-flex justify-content-end gap-2 mt-4">
-            <button type="button" class="btn btn-outline-secondary" (click)="cancelForm()">Cancelar</button>
-            <button type="submit" class="btn btn-primary" [disabled]="saving()">
-              {{ saving() ? 'Guardando...' : 'Guardar' }}
-            </button>
-          </div>
-        </fieldset>
-      </form>
-    </div>
-  </section>
+            <div class="d-flex justify-content-end gap-2">
+              <button type="button" class="btn btn-outline-secondary" (click)="cancelForm()">Cancelar</button>
+              <button type="submit" class="btn btn-primary" [disabled]="saving()">
+                {{ saving() ? 'Guardando...' : 'Guardar' }}
+              </button>
+            </div>
+          </form>
+        </div>
+      </div>
+    </section>
 
     <ng-container *ngIf="!showForm()">
       <div class="categoria-grid" *ngIf="!loading() && categorias().length > 0; else emptyState">

--- a/fnanz-app/src/app/features/categorias-financieras/categorias-financieras.component.html
+++ b/fnanz-app/src/app/features/categorias-financieras/categorias-financieras.component.html
@@ -141,23 +141,52 @@
                   <td class="text-end">
                     <button
                       type="button"
-                      class="btn btn-outline-secondary btn-sm me-1"
+                      class="btn btn-info action-icon-button me-1"
                       (click)="startEdit(categoria)"
                       [disabled]="loading() || saving()"
                       [attr.aria-label]="'Editar categoria: ' + categoria.nombre"
                       [attr.title]="'Editar categoria'"
                     >
-                      Editar
+                      <svg
+                        viewBox="0 0 24 24"
+                        fill="none"
+                        stroke="currentColor"
+                        stroke-width="1.5"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        aria-hidden="true"
+                      >
+                        <path d="M12 20h9" />
+                        <path
+                          d="M16.5 3.5a2.121 2.121 0 0 1 3 3L7 19l-4 1 1-4 12.5-12.5z"
+                        />
+                      </svg>
+                      <span class="visually-hidden">Editar</span>
                     </button>
                     <button
                       type="button"
-                      class="btn btn-outline-danger btn-sm"
+                      class="btn btn-warning action-icon-button"
                       (click)="promptDelete(categoria)"
                       [disabled]="loading() || saving()"
                       [attr.aria-label]="'Eliminar categoria: ' + categoria.nombre"
                       [attr.title]="'Eliminar categoria'"
                     >
-                      Eliminar
+                      <svg
+                        viewBox="0 0 24 24"
+                        fill="none"
+                        stroke="currentColor"
+                        stroke-width="1.5"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        aria-hidden="true"
+                      >
+                        <polyline points="3 6 5 6 21 6" />
+                        <path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6" />
+                        <path d="M10 11v6" />
+                        <path d="M14 11v6" />
+                        <path d="M9 6V4a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v2" />
+                      </svg>
+                      <span class="visually-hidden">Eliminar</span>
                     </button>
                   </td>
                 </tr>

--- a/fnanz-app/src/app/features/categorias-financieras/categorias-financieras.component.html
+++ b/fnanz-app/src/app/features/categorias-financieras/categorias-financieras.component.html
@@ -122,10 +122,7 @@
               </thead>
               <tbody>
                 <tr *ngFor="let categoria of categorias(); trackBy: trackByCategoriaId">
-                  <td>
-                    <div class="fw-semibold">{{ categoria.nombre }}</div>
-                    <small class="text-muted">Creada {{ categoria.creadoEn | date: 'short' }}</small>
-                  </td>
+                  <td class="fw-semibold">{{ categoria.nombre }}</td>
                   <td>
                     <span class="tipo-pill" [ngClass]="categoria.tipo === 'INGRESO' ? 'tipo-pill--ingreso' : 'tipo-pill--egreso'">
                       {{ categoria.tipo }}

--- a/fnanz-app/src/app/features/categorias-financieras/categorias-financieras.component.html
+++ b/fnanz-app/src/app/features/categorias-financieras/categorias-financieras.component.html
@@ -105,100 +105,102 @@
     </div>
   </section>
 
-    <div class="categoria-grid" *ngIf="!loading() && categorias().length > 0; else emptyState">
-      <div class="card border-0 shadow-sm mt-4">
-        <div class="card-body p-0">
-          <div class="table-responsive">
-            <table class="table table-hover align-middle mb-0">
-              <thead class="table-light">
-                <tr>
-                  <th scope="col">Nombre</th>
-                  <th scope="col">Tipo</th>
-                  <th scope="col">Estado</th>
-                  <th scope="col">Orden</th>
-                  <th scope="col">Descripción</th>
-                  <th scope="col" class="text-end">Acciones</th>
-                </tr>
-              </thead>
-              <tbody>
-                <tr *ngFor="let categoria of categorias(); trackBy: trackByCategoriaId">
-                  <td class="fw-semibold">{{ categoria.nombre }}</td>
-                  <td>
-                    <span class="tipo-pill" [ngClass]="categoria.tipo === 'INGRESO' ? 'tipo-pill--ingreso' : 'tipo-pill--egreso'">
-                      {{ categoria.tipo }}
-                    </span>
-                  </td>
-                  <td>
-                    <span [ngClass]="categoria.activo ? 'estado estado--activo' : 'estado estado--inactivo'">
-                      {{ categoria.activo ? 'Activo' : 'Inactivo' }}
-                    </span>
-                  </td>
-                  <td>{{ categoria.orden ?? '—' }}</td>
-                  <td>{{ categoria.descripcion || 'Sin descripción' }}</td>
-                  <td class="text-end">
-                    <button
-                      type="button"
-                      class="btn btn-outline-primary action-icon-button me-1"
-                      (click)="startEdit(categoria)"
-                      [disabled]="loading() || saving()"
-                      [attr.aria-label]="'Editar categoria: ' + categoria.nombre"
-                      [attr.title]="'Editar categoria'"
-                    >
-                      <svg
-                        viewBox="0 0 24 24"
-                        fill="none"
-                        stroke="currentColor"
-                        stroke-width="1.5"
-                        stroke-linecap="round"
-                        stroke-linejoin="round"
-                        aria-hidden="true"
+    <ng-container *ngIf="!showForm()">
+      <div class="categoria-grid" *ngIf="!loading() && categorias().length > 0; else emptyState">
+        <div class="card border-0 shadow-sm mt-4">
+          <div class="card-body p-0">
+            <div class="table-responsive">
+              <table class="table table-hover align-middle mb-0">
+                <thead class="table-light">
+                  <tr>
+                    <th scope="col">Nombre</th>
+                    <th scope="col">Tipo</th>
+                    <th scope="col">Estado</th>
+                    <th scope="col">Orden</th>
+                    <th scope="col">Descripción</th>
+                    <th scope="col" class="text-end">Acciones</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr *ngFor="let categoria of categorias(); trackBy: trackByCategoriaId">
+                    <td class="fw-semibold">{{ categoria.nombre }}</td>
+                    <td>
+                      <span class="tipo-pill" [ngClass]="categoria.tipo === 'INGRESO' ? 'tipo-pill--ingreso' : 'tipo-pill--egreso'">
+                        {{ categoria.tipo }}
+                      </span>
+                    </td>
+                    <td>
+                      <span [ngClass]="categoria.activo ? 'estado estado--activo' : 'estado estado--inactivo'">
+                        {{ categoria.activo ? 'Activo' : 'Inactivo' }}
+                      </span>
+                    </td>
+                    <td>{{ categoria.orden ?? '—' }}</td>
+                    <td>{{ categoria.descripcion || 'Sin descripción' }}</td>
+                    <td class="text-end">
+                      <button
+                        type="button"
+                        class="btn btn-outline-primary action-icon-button me-1"
+                        (click)="startEdit(categoria)"
+                        [disabled]="loading() || saving()"
+                        [attr.aria-label]="'Editar categoria: ' + categoria.nombre"
+                        [attr.title]="'Editar categoria'"
                       >
-                        <path d="M12 20h9" />
-                        <path
-                          d="M16.5 3.5a2.121 2.121 0 0 1 3 3L7 19l-4 1 1-4 12.5-12.5z"
-                        />
-                      </svg>
-                      <span class="visually-hidden">Editar</span>
-                    </button>
-                    <button
-                      type="button"
-                      class="btn btn-outline-danger action-icon-button"
-                      (click)="promptDelete(categoria)"
-                      [disabled]="loading() || saving()"
-                      [attr.aria-label]="'Eliminar categoria: ' + categoria.nombre"
-                      [attr.title]="'Eliminar categoria'"
-                    >
-                      <svg
-                        viewBox="0 0 24 24"
-                        fill="none"
-                        stroke="currentColor"
-                        stroke-width="1.5"
-                        stroke-linecap="round"
-                        stroke-linejoin="round"
-                        aria-hidden="true"
+                        <svg
+                          viewBox="0 0 24 24"
+                          fill="none"
+                          stroke="currentColor"
+                          stroke-width="1.5"
+                          stroke-linecap="round"
+                          stroke-linejoin="round"
+                          aria-hidden="true"
+                        >
+                          <path d="M12 20h9" />
+                          <path
+                            d="M16.5 3.5a2.121 2.121 0 0 1 3 3L7 19l-4 1 1-4 12.5-12.5z"
+                          />
+                        </svg>
+                        <span class="visually-hidden">Editar</span>
+                      </button>
+                      <button
+                        type="button"
+                        class="btn btn-outline-danger action-icon-button"
+                        (click)="promptDelete(categoria)"
+                        [disabled]="loading() || saving()"
+                        [attr.aria-label]="'Eliminar categoria: ' + categoria.nombre"
+                        [attr.title]="'Eliminar categoria'"
                       >
-                        <polyline points="3 6 5 6 21 6" />
-                        <path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6" />
-                        <path d="M10 11v6" />
-                        <path d="M14 11v6" />
-                        <path d="M9 6V4a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v2" />
-                      </svg>
-                      <span class="visually-hidden">Eliminar</span>
-                    </button>
-                  </td>
-                </tr>
-              </tbody>
-            </table>
+                        <svg
+                          viewBox="0 0 24 24"
+                          fill="none"
+                          stroke="currentColor"
+                          stroke-width="1.5"
+                          stroke-linecap="round"
+                          stroke-linejoin="round"
+                          aria-hidden="true"
+                        >
+                          <polyline points="3 6 5 6 21 6" />
+                          <path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6" />
+                          <path d="M10 11v6" />
+                          <path d="M14 11v6" />
+                          <path d="M9 6V4a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v2" />
+                        </svg>
+                        <span class="visually-hidden">Eliminar</span>
+                      </button>
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
           </div>
         </div>
       </div>
-    </div>
 
-    <ng-template #emptyState>
-      <div class="alert alert-secondary mt-4" *ngIf="!loading()">
-        No hay categorias registradas aún. Crea la primera para comenzar.
-      </div>
-    </ng-template>
+      <ng-template #emptyState>
+        <div class="alert alert-secondary mt-4" *ngIf="!loading()">
+          No hay categorias registradas aún. Crea la primera para comenzar.
+        </div>
+      </ng-template>
+    </ng-container>
 
     <ng-container *ngIf="categoriaPendingDelete() as categoria">
       <div

--- a/fnanz-app/src/app/features/categorias-financieras/categorias-financieras.component.html
+++ b/fnanz-app/src/app/features/categorias-financieras/categorias-financieras.component.html
@@ -203,17 +203,54 @@
       </div>
     </ng-template>
 
-    <app-confirm-dialog
-      [open]="categoriaPendingDelete() !== null"
-      title="Eliminar categoria"
-      [message]="deleteMessage()"
-      confirmLabel="Eliminar"
-      cancelLabel="Cancelar"
-      busyLabel="Eliminando..."
-      [busy]="deleting()"
-      [confirmDestructive]="true"
-      (cancel)="closeDeleteDialog()"
-      (confirm)="confirmDeleteCategoria()"
-    ></app-confirm-dialog>
+    <ng-container *ngIf="categoriaPendingDelete() as categoria">
+      <div
+        class="modal fade show d-block categoria-delete-modal"
+        tabindex="-1"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="categoriaDeleteModalLabel"
+      >
+        <div class="modal-dialog" role="document">
+          <div class="modal-content">
+            <div class="modal-header">
+              <h5 class="modal-title" id="categoriaDeleteModalLabel">Eliminar categoria</h5>
+              <button
+                type="button"
+                class="btn-close"
+                aria-label="Cerrar"
+                (click)="closeDeleteDialog()"
+                [disabled]="deleting()"
+              >
+                <span aria-hidden="true"></span>
+              </button>
+            </div>
+            <div class="modal-body">
+              <p>¿Desea eliminar la categoria "{{ categoria.nombre }}"?</p>
+              <p class="mb-0 text-muted">Esta acción no se puede deshacer.</p>
+            </div>
+            <div class="modal-footer">
+              <button
+                type="button"
+                class="btn btn-danger"
+                (click)="confirmDeleteCategoria()"
+                [disabled]="deleting()"
+              >
+                {{ deleting() ? 'Eliminando...' : 'Eliminar' }}
+              </button>
+              <button
+                type="button"
+                class="btn btn-secondary"
+                (click)="closeDeleteDialog()"
+                [disabled]="deleting()"
+              >
+                Cancelar
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div class="modal-backdrop fade show" style="display: block;"></div>
+    </ng-container>
   </div>
 </section>

--- a/fnanz-app/src/app/features/categorias-financieras/categorias-financieras.component.html
+++ b/fnanz-app/src/app/features/categorias-financieras/categorias-financieras.component.html
@@ -16,7 +16,7 @@
     <div *ngIf="error() && !loading()" class="alert alert-danger mt-3 mb-0" role="alert">{{ error() }}</div>
 
     <section *ngIf="showForm()" class="categoria-form-wrapper mt-4">
-      <div class="card border-dark mb-3 categoria-form-card">
+      <div class="card border-dark categoria-form-card">
         <div class="card-header">
           <h5 class="mb-0">{{ formTitle() }}</h5>
         </div>

--- a/fnanz-app/src/app/features/categorias-financieras/categorias-financieras.component.html
+++ b/fnanz-app/src/app/features/categorias-financieras/categorias-financieras.component.html
@@ -141,7 +141,7 @@
                   <td class="text-end">
                     <button
                       type="button"
-                      class="btn btn-info action-icon-button me-1"
+                      class="btn btn-outline-primary action-icon-button me-1"
                       (click)="startEdit(categoria)"
                       [disabled]="loading() || saving()"
                       [attr.aria-label]="'Editar categoria: ' + categoria.nombre"
@@ -165,7 +165,7 @@
                     </button>
                     <button
                       type="button"
-                      class="btn btn-warning action-icon-button"
+                      class="btn btn-outline-danger action-icon-button"
                       (click)="promptDelete(categoria)"
                       [disabled]="loading() || saving()"
                       [attr.aria-label]="'Eliminar categoria: ' + categoria.nombre"

--- a/fnanz-app/src/app/features/categorias-financieras/categorias-financieras.component.scss
+++ b/fnanz-app/src/app/features/categorias-financieras/categorias-financieras.component.scss
@@ -73,3 +73,11 @@
   height: 1.25rem;
   width: 1.25rem;
 }
+
+.categoria-delete-modal {
+  background-color: rgba(33, 37, 41, 0.6);
+}
+
+.categoria-delete-modal .modal-dialog {
+  margin-top: 10vh;
+}

--- a/fnanz-app/src/app/features/categorias-financieras/categorias-financieras.component.scss
+++ b/fnanz-app/src/app/features/categorias-financieras/categorias-financieras.component.scss
@@ -58,3 +58,18 @@
   background-color: #fee2e2;
   color: #b91c1c;
 }
+
+.action-icon-button {
+  align-items: center;
+  border-radius: 999px;
+  display: inline-flex;
+  height: 2.5rem;
+  justify-content: center;
+  padding: 0;
+  width: 2.5rem;
+}
+
+.action-icon-button svg {
+  height: 1.25rem;
+  width: 1.25rem;
+}

--- a/fnanz-app/src/app/features/categorias-financieras/categorias-financieras.component.scss
+++ b/fnanz-app/src/app/features/categorias-financieras/categorias-financieras.component.scss
@@ -10,10 +10,10 @@
 .categoria-form-wrapper {
   display: flex;
   justify-content: flex-start;
+  width: 100%;
 }
 
 .categoria-form-card {
-  max-width: 20rem;
   width: 100%;
 }
 

--- a/fnanz-app/src/app/features/categorias-financieras/categorias-financieras.component.scss
+++ b/fnanz-app/src/app/features/categorias-financieras/categorias-financieras.component.scss
@@ -7,21 +7,14 @@
   margin-bottom: 1rem;
 }
 
-.categoria-form {
-  border-radius: 1rem;
+.categoria-form-wrapper {
+  display: flex;
+  justify-content: flex-start;
 }
 
-.categoria-form__fieldset {
-  border: 1px solid rgba(0, 0, 0, 0.075);
-  border-radius: 1rem;
-  margin: 0;
-  padding: 1.5rem;
-}
-
-.categoria-form__legend {
-  font-size: 1.25rem;
-  font-weight: 600;
-  margin-bottom: 1.5rem;
+.categoria-form-card {
+  max-width: 20rem;
+  width: 100%;
 }
 
 .tipo-pill {

--- a/fnanz-app/src/app/features/categorias-financieras/categorias-financieras.component.ts
+++ b/fnanz-app/src/app/features/categorias-financieras/categorias-financieras.component.ts
@@ -7,13 +7,11 @@ import {
   CategoriaFinancieraCreate,
 } from '../../shared/models/categoria-financiera.model';
 import { CategoriaFinancieraService } from '../../core/services/categoria-financiera.service';
-import { ConfirmDialogComponent } from '../../shared/components/confirm-dialog/confirm-dialog.component';
 
 @Component({
   selector: 'app-categorias-financieras',
   standalone: true,
   imports: [
-    ConfirmDialogComponent,
     DatePipe,
     NgClass,
     NgFor,
@@ -50,11 +48,6 @@ export class CategoriasFinancierasComponent implements OnInit {
       ? `Editar categoria: ${this.selectedCategoria()!.nombre}`
       : 'Nueva categoria'
   );
-
-  readonly deleteMessage = computed(() => {
-    const categoria = this.categoriaPendingDelete();
-    return categoria ? `¿Desea eliminar la categoria "${categoria.nombre}"?` : '';
-  });
 
   ngOnInit(): void {
     this.loadCategorias();

--- a/fnanz-app/src/app/features/partidas-presupuestarias/partidas-presupuestarias.component.html
+++ b/fnanz-app/src/app/features/partidas-presupuestarias/partidas-presupuestarias.component.html
@@ -131,21 +131,21 @@
   </section>
 
   <div *ngIf="!showForm() && !viewingPartida()" class="partida-grid">
-    <table class="data-table">
+    <table class="table table-hover budget-table">
       <thead>
         <tr>
-          <th>Concepto</th>
-          <th>Tipo</th>
-          <th>Categoría</th>
-          <th>Estado</th>
-          <th>Monto reservado</th>
-          <th>Monto aplicado</th>
-          <th class="data-table__actions">Acciones</th>
+          <th scope="col">Concepto</th>
+          <th scope="col">Tipo</th>
+          <th scope="col">Categoría</th>
+          <th scope="col">Estado</th>
+          <th scope="col">Monto reservado</th>
+          <th scope="col">Monto aplicado</th>
+          <th scope="col" class="budget-table__actions">Acciones</th>
         </tr>
       </thead>
       <tbody>
         <tr *ngIf="partidas().length === 0">
-          <td class="data-table__empty" colspan="7">
+          <td class="budget-table__empty" colspan="7">
             <ng-container *ngIf="loading(); else emptyMessage">
               Cargando información...
             </ng-container>
@@ -158,10 +158,13 @@
             </ng-template>
           </td>
         </tr>
-        <tr *ngFor="let partida of partidas(); trackBy: trackByPartidaId">
-          <td>
+        <tr
+          *ngFor="let partida of partidas(); trackBy: trackByPartidaId"
+          [ngClass]="estadoRowClass(partida)"
+        >
+          <th scope="row">
             <div class="partida-name">{{ partida.concepto }}</div>
-          </td>
+          </th>
           <td>
             <span class="tipo-pill" [ngClass]="partida.tipo === 'INGRESO' ? 'tipo-pill--ingreso' : 'tipo-pill--egreso'">
               {{ partida.tipo }}
@@ -171,9 +174,9 @@
           <td>
             <span [ngClass]="'estado estado--' + partida.estado.toLowerCase()">{{ partida.estado }}</span>
           </td>
-          <td class="data-table__numeric">{{ formatAccounting(partida.montoReservado) }}</td>
-          <td class="data-table__numeric">{{ formatAccounting(partida.montoAplicado) }}</td>
-          <td class="data-table__actions">
+          <td class="budget-table__numeric">{{ formatAccounting(partida.montoReservado) }}</td>
+          <td class="budget-table__numeric">{{ formatAccounting(partida.montoAplicado) }}</td>
+          <td class="budget-table__actions">
             <button
               type="button"
               class="ghost-button icon-button"

--- a/fnanz-app/src/app/features/partidas-presupuestarias/partidas-presupuestarias.component.html
+++ b/fnanz-app/src/app/features/partidas-presupuestarias/partidas-presupuestarias.component.html
@@ -1,396 +1,489 @@
 <section class="card partida-panel shadow-sm border-0">
   <div class="card-body">
-    <header class="partida-panel__header">
-    <div>
-      <h2 class="card-title mb-1">Presupuestos</h2>
-      <p class="card-subtitle text-muted">
-        Administra las partidas presupuestarias asignadas a los periodos financieros de tu organización.
-      </p>
-    </div>
-    <button
-      type="button"
-      class="btn btn-primary"
-      (click)="startCreate()"
-      [disabled]="loading() || saving() || selectedPeriodoId() === null"
-    >
-      Nueva partida presupuestaria
-    </button>
-  </header>
-
-  <p *ngIf="loading()" class="partida-panel__loading">Cargando información...</p>
-  <p *ngIf="error() && !loading()" class="partida-panel__error">{{ error() }}</p>
-  <p *ngIf="categoriasError()" class="partida-panel__warning">{{ categoriasError() }}</p>
-  <p *ngIf="periodosError()" class="partida-panel__warning">{{ periodosError() }}</p>
-  <p *ngIf="periodosDropdownError()" class="partida-panel__warning">{{ periodosDropdownError() }}</p>
-
-  <section *ngIf="!showForm() && !viewingPartida()" class="partida-panel__filters">
-    <label class="filter-field">
-      <span>Periodo</span>
-      <select
-        [disabled]="periodosDropdownLoading() || periodosDropdown().length === 0"
-        [value]="selectedPeriodoId() ?? ''"
-        (change)="onPeriodoDropdownChange($any($event.target).value)"
-      >
-        <option value="">Selecciona un periodo</option>
-        <option *ngFor="let periodo of periodosDropdown()" [value]="periodo.id">
-          {{ periodo.nombre }}
-        </option>
-      </select>
-    </label>
-
-    <label class="filter-checkbox">
-      <input
-        type="checkbox"
-        [checked]="includePeriodosCerrados()"
-        (change)="onIncludePeriodosCerradosChange($any($event.target).checked)"
-      />
-      <span>Incluir periodos cerrados</span>
-    </label>
-  </section>
-
-  <p *ngIf="periodosDropdownLoading() && !showForm() && !viewingPartida()" class="partida-panel__loading">
-    Cargando periodos...
-  </p>
-
-  <section *ngIf="showForm()" class="partida-form">
-    <h3>{{ formTitle() }}</h3>
-    <form [formGroup]="form" (ngSubmit)="submitForm()" class="partida-form__grid">
-      <label class="form-field" [class.form-field--invalid]="hasControlError('tipo')">
-        <span>Tipo *</span>
-        <select formControlName="tipo">
-          <option *ngFor="let tipo of tipoOptions" [value]="tipo">{{ tipo }}</option>
-        </select>
-        <small *ngIf="getServerError('tipo') as serverError">{{ serverError }}</small>
-      </label>
-
-      <label class="form-field" [class.form-field--invalid]="hasControlError('categoriaId')">
-        <span>Categoría *</span>
-        <select formControlName="categoriaId" [disabled]="categoriasLoading() || categorias().length === 0">
-          <option [ngValue]="null" disabled>Seleccione una categoría</option>
-          <option *ngFor="let categoria of categorias()" [ngValue]="categoria.id">
-            {{ categoria.nombre }} ({{ categoria.tipo }})
-          </option>
-        </select>
-        <small *ngIf="form.controls.categoriaId.touched && form.controls.categoriaId.hasError('required')">
-          La categoría es obligatoria.
-        </small>
-        <small *ngIf="getServerError('categoriaId') as serverError">{{ serverError }}</small>
-        <small *ngIf="!categoriasLoading() && categorias().length === 0">
-          Debes crear al menos una categoría para asignarla a la partida presupuestaria.
-        </small>
-      </label>
-
-      <label class="form-field" [class.form-field--invalid]="hasControlError('concepto')">
-        <span>Concepto *</span>
-        <input type="text" formControlName="concepto" [class.invalid]="form.controls.concepto.touched && form.controls.concepto.invalid" />
-        <small *ngIf="form.controls.concepto.touched && form.controls.concepto.hasError('required')">
-          El concepto es obligatorio.
-        </small>
-        <small *ngIf="form.controls.concepto.touched && form.controls.concepto.hasError('maxlength')">
-          El concepto debe tener menos de 120 caracteres.
-        </small>
-        <small *ngIf="getServerError('concepto') as serverError">{{ serverError }}</small>
-      </label>
-
-      <label class="form-field" [class.form-field--invalid]="hasControlError('montoReservado')">
-        <span>Monto reservado *</span>
-        <input
-          type="number"
-          formControlName="montoReservado"
-          step="0.01"
-          min="0"
-          [class.invalid]="form.controls.montoReservado.touched && form.controls.montoReservado.invalid"
-        />
-        <small *ngIf="form.controls.montoReservado.touched && form.controls.montoReservado.hasError('required')">
-          El monto reservado es obligatorio.
-        </small>
-        <small *ngIf="form.controls.montoReservado.touched && form.controls.montoReservado.hasError('min')">
-          El monto reservado no puede ser negativo.
-        </small>
-        <small *ngIf="getServerError('montoReservado') as serverError">{{ serverError }}</small>
-      </label>
-
-      <label class="form-field form-field--full" [class.form-field--invalid]="hasControlError('nota')">
-        <span>Nota</span>
-        <textarea rows="3" formControlName="nota"></textarea>
-        <small *ngIf="form.controls.nota.touched && form.controls.nota.hasError('maxlength')">
-          La nota debe tener menos de 500 caracteres.
-        </small>
-        <small *ngIf="getServerError('nota') as serverError">{{ serverError }}</small>
-      </label>
-
-      <div class="form-actions">
-        <button type="button" class="ghost-button" (click)="promptCancelForm()" [disabled]="saving()">
-          Cancelar
-        </button>
-        <button type="submit" class="primary-button" [disabled]="saving()">
-          {{ saving() ? 'Guardando...' : 'Guardar' }}
-        </button>
-      </div>
-    </form>
-  </section>
-
-  <div *ngIf="!showForm() && !viewingPartida()" class="partida-grid">
-    <table class="table table-hover budget-table">
-      <thead>
-        <tr>
-          <th scope="col">Concepto</th>
-          <th scope="col">Tipo</th>
-          <th scope="col">Categoría</th>
-          <th scope="col">Estado</th>
-          <th scope="col">Monto reservado</th>
-          <th scope="col">Monto aplicado</th>
-          <th scope="col" class="budget-table__actions">Acciones</th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr *ngIf="partidas().length === 0">
-          <td class="budget-table__empty" colspan="7">
-            <ng-container *ngIf="loading(); else emptyMessage">
-              Cargando información...
-            </ng-container>
-            <ng-template #emptyMessage>
-              {{
-                selectedPeriodoId() === null
-                  ? 'Selecciona un periodo para ver las partidas presupuestarias.'
-                  : 'No hay partidas presupuestarias registradas para el periodo seleccionado.'
-              }}
-            </ng-template>
-          </td>
-        </tr>
-        <tr
-          *ngFor="let partida of partidas(); trackBy: trackByPartidaId"
-          [ngClass]="estadoRowClass(partida)"
-        >
-          <th scope="row">
-            <div class="partida-name">{{ partida.concepto }}</div>
-          </th>
-          <td>
-            <span class="tipo-pill" [ngClass]="partida.tipo === 'INGRESO' ? 'tipo-pill--ingreso' : 'tipo-pill--egreso'">
-              {{ partida.tipo }}
-            </span>
-          </td>
-          <td>{{ partida.categoriaNombre }}</td>
-          <td>
-            <span [ngClass]="'estado estado--' + partida.estado.toLowerCase()">{{ partida.estado }}</span>
-          </td>
-          <td class="budget-table__numeric">{{ formatAccounting(partida.montoReservado) }}</td>
-          <td class="budget-table__numeric">{{ formatAccounting(partida.montoAplicado) }}</td>
-          <td class="budget-table__actions">
-            <button
-              type="button"
-              class="ghost-button icon-button"
-              (click)="viewPartida(partida)"
-              [disabled]="loading() || saving()"
-              [attr.aria-label]="'Ver partida presupuestaria: ' + partida.concepto"
-              [attr.title]="'Ver partida presupuestaria'"
-            >
-              <svg
-                viewBox="0 0 24 24"
-                fill="none"
-                stroke="currentColor"
-                stroke-width="1.5"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                aria-hidden="true"
-              >
-                <path d="M1 12s4-7 11-7 11 7 11 7-4 7-11 7-11-7-11-7z" />
-                <circle cx="12" cy="12" r="3" />
-              </svg>
-            </button>
-            <button
-              type="button"
-              class="danger-button icon-button"
-              (click)="promptDelete(partida)"
-              [disabled]="loading() || saving()"
-              [attr.aria-label]="'Eliminar partida presupuestaria: ' + partida.concepto"
-              [attr.title]="'Eliminar partida presupuestaria'"
-            >
-              <svg
-                viewBox="0 0 24 24"
-                fill="none"
-                stroke="currentColor"
-                stroke-width="1.5"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                aria-hidden="true"
-              >
-                <polyline points="3 6 5 6 21 6" />
-                <path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6" />
-                <path d="M10 11v6" />
-                <path d="M14 11v6" />
-                <path d="M9 6V4a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v2" />
-              </svg>
-            </button>
-          </td>
-        </tr>
-      </tbody>
-    </table>
-  </div>
-
-  <app-confirm-dialog
-    [open]="partidaPendingDelete() !== null"
-    title="Eliminar partida presupuestaria"
-    [message]="deleteMessage()"
-    confirmLabel="Eliminar"
-    cancelLabel="Cancelar"
-    busyLabel="Eliminando..."
-    [busy]="deleting()"
-    [confirmDestructive]="true"
-    (cancel)="closeDeleteDialog()"
-    (confirm)="confirmDeletePartida()"
-  ></app-confirm-dialog>
-
-  <app-confirm-dialog
-    [open]="cancelDialogOpen()"
-    [title]="cancelDialogTitle()"
-    [message]="cancelDialogMessage()"
-    confirmLabel="Sí, cancelar"
-    cancelLabel="Seguir creando"
-    (cancel)="closeCancelDialog()"
-    (confirm)="confirmCancelForm()"
-  ></app-confirm-dialog>
-
-  <section *ngIf="!showForm() && viewingPartida() as partida" class="partida-form">
-    <header class="partida-panel__header">
+    <div class="partida-panel__header">
       <div>
-        <h3>{{ partida.concepto }}</h3>
-        <p class="partida-panel__subtitle">Actualizado {{ partida.actualizadoEn | date: 'short' }}</p>
-      </div>
-    </header>
-
-    <div class="partida-form__grid">
-      <div class="form-field form-field--static">
-        <span>Tipo</span>
-        <p class="form-field__readonly">
-          <span
-            class="tipo-pill"
-            [ngClass]="partida.tipo === 'INGRESO' ? 'tipo-pill--ingreso' : 'tipo-pill--egreso'"
-          >
-            {{ partida.tipo }}
-          </span>
+        <h2 class="card-title mb-1">Presupuestos</h2>
+        <p class="card-subtitle text-muted">
+          Administra las partidas presupuestarias asignadas a los periodos financieros de tu organización.
         </p>
       </div>
-
-      <div class="form-field form-field--static">
-        <span>Categoría</span>
-        <p class="form-field__readonly">{{ partida.categoriaNombre }}</p>
-      </div>
-
-      <div class="form-field form-field--static">
-        <span>Estado</span>
-        <p class="form-field__readonly">
-          <span class="estado" [ngClass]="'estado--' + partida.estado.toLowerCase()">{{ partida.estado }}</span>
-        </p>
-      </div>
-
-      <div class="form-field form-field--static form-field--full">
-        <span>Periodo</span>
-        <p class="form-field__readonly">
-          {{ partida.periodoNombre }}
-          ({{ partida.periodoFechaInicio | date: 'longDate' }} - {{ partida.periodoFechaFin | date: 'longDate' }})
-        </p>
-      </div>
-
-      <div class="form-field form-field--static">
-        <span>Monto reservado</span>
-        <p
-          class="form-field__readonly"
-          style="display: flex; align-items: center; justify-content: space-between; gap: 0.75rem;"
-        >
-          <span>{{ formatAccounting(partida.montoReservado) }}</span>
-          <button
-            *ngIf="partida.estado === 'RESERVADO'"
-            type="button"
-            class="primary-button"
-            style="padding: 0.35rem 0.75rem;"
-            (click)="startApplyMonto(partida)"
-            [disabled]="applyingMonto() || applyingMontoSaving()"
-          >
-            Aplicar
-          </button>
-        </p>
-      </div>
-
-      <div
-        class="form-field form-field--static"
-        [class.form-field--invalid]="applyingMonto() && montoAplicadoControl.touched && montoAplicadoControl.invalid"
+      <button
+        type="button"
+        class="btn btn-primary"
+        (click)="startCreate()"
+        [disabled]="loading() || saving() || selectedPeriodoId() === null"
       >
-        <span>Monto aplicado</span>
-        <ng-container *ngIf="applyingMonto(); else appliedReadonly">
-          <div style="display: flex; align-items: center; gap: 0.75rem;">
-            <div style="flex: 1;">
-              <input
-                type="number"
-                min="0"
-                step="0.01"
-                [formControl]="montoAplicadoControl"
-                style="width: 100%;"
-              />
+        Nueva partida presupuestaria
+      </button>
+    </div>
+
+    <div *ngIf="loading()" class="alert alert-info mt-3 mb-0" role="status">Cargando información...</div>
+    <div *ngIf="error() && !loading()" class="alert alert-danger mt-3 mb-0" role="alert">{{ error() }}</div>
+    <div *ngIf="categoriasError() && !loading()" class="alert alert-warning mt-3 mb-0" role="alert">
+      {{ categoriasError() }}
+    </div>
+    <div *ngIf="periodosError() && !loading()" class="alert alert-warning mt-3 mb-0" role="alert">
+      {{ periodosError() }}
+    </div>
+    <div *ngIf="periodosDropdownError() && !loading()" class="alert alert-warning mt-3 mb-0" role="alert">
+      {{ periodosDropdownError() }}
+    </div>
+
+    <section *ngIf="!showForm() && !viewingPartida()" class="partida-filters mt-4">
+      <div class="row g-3 align-items-end">
+        <div class="col-12 col-md-6 col-lg-4">
+          <label for="partidaFiltroPeriodo" class="form-label fw-semibold">Periodo</label>
+          <select
+            id="partidaFiltroPeriodo"
+            class="form-select"
+            [disabled]="periodosDropdownLoading() || periodosDropdown().length === 0"
+            [value]="selectedPeriodoId() ?? ''"
+            (change)="onPeriodoDropdownChange($any($event.target).value)"
+          >
+            <option value="">Selecciona un periodo</option>
+            <option *ngFor="let periodo of periodosDropdown()" [value]="periodo.id">
+              {{ periodo.nombre }}
+            </option>
+          </select>
+        </div>
+        <div class="col-12 col-md-6 col-lg-4">
+          <div class="form-check form-switch">
+            <input
+              class="form-check-input"
+              type="checkbox"
+              id="partidaFiltroCerrados"
+              [checked]="includePeriodosCerrados()"
+              (change)="onIncludePeriodosCerradosChange($any($event.target).checked)"
+            />
+            <label class="form-check-label" for="partidaFiltroCerrados">Incluir periodos cerrados</label>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <div
+      *ngIf="periodosDropdownLoading() && !showForm() && !viewingPartida()"
+      class="alert alert-info mt-3 mb-0"
+      role="status"
+    >
+      Cargando periodos...
+    </div>
+
+    <section *ngIf="showForm()" class="partida-form-wrapper mt-4">
+      <div class="card border-dark partida-form-card">
+        <div class="card-header">
+          <h5 class="mb-0">{{ formTitle() }}</h5>
+        </div>
+        <div class="card-body">
+          <form [formGroup]="form" (ngSubmit)="submitForm()" novalidate>
+            <div class="row g-3">
+              <div class="col-12 col-md-6">
+                <label for="partidaTipo" class="form-label fw-semibold">Tipo *</label>
+                <select
+                  id="partidaTipo"
+                  class="form-select"
+                  formControlName="tipo"
+                  [class.is-invalid]="hasControlError('tipo')"
+                >
+                  <option *ngFor="let tipo of tipoOptions" [value]="tipo">{{ tipo }}</option>
+                </select>
+                <div class="invalid-feedback d-block" *ngIf="getServerError('tipo') as serverError">
+                  {{ serverError }}
+                </div>
+              </div>
+
+              <div class="col-12 col-md-6">
+                <label for="partidaCategoria" class="form-label fw-semibold">Categoría *</label>
+                <select
+                  id="partidaCategoria"
+                  class="form-select"
+                  formControlName="categoriaId"
+                  [disabled]="categoriasLoading() || categorias().length === 0"
+                  [class.is-invalid]="hasControlError('categoriaId')"
+                >
+                  <option [ngValue]="null" disabled>Seleccione una categoría</option>
+                  <option *ngFor="let categoria of categorias()" [ngValue]="categoria.id">
+                    {{ categoria.nombre }} ({{ categoria.tipo }})
+                  </option>
+                </select>
+                <div class="invalid-feedback" *ngIf="form.controls.categoriaId.touched && form.controls.categoriaId.hasError('required')">
+                  La categoría es obligatoria.
+                </div>
+                <div class="invalid-feedback d-block" *ngIf="getServerError('categoriaId') as serverError">
+                  {{ serverError }}
+                </div>
+                <div class="form-text" *ngIf="!categoriasLoading() && categorias().length === 0">
+                  Debes crear al menos una categoría para asignarla a la partida presupuestaria.
+                </div>
+              </div>
+
+              <div class="col-12">
+                <label for="partidaConcepto" class="form-label fw-semibold">Concepto *</label>
+                <input
+                  id="partidaConcepto"
+                  type="text"
+                  class="form-control"
+                  formControlName="concepto"
+                  [class.is-invalid]="form.controls.concepto.touched && form.controls.concepto.invalid"
+                />
+                <div class="invalid-feedback" *ngIf="form.controls.concepto.touched && form.controls.concepto.hasError('required')">
+                  El concepto es obligatorio.
+                </div>
+                <div class="invalid-feedback" *ngIf="form.controls.concepto.touched && form.controls.concepto.hasError('maxlength')">
+                  El concepto debe tener menos de 120 caracteres.
+                </div>
+                <div class="invalid-feedback d-block" *ngIf="getServerError('concepto') as serverError">
+                  {{ serverError }}
+                </div>
+              </div>
+
+              <div class="col-12 col-md-6">
+                <label for="partidaMontoReservado" class="form-label fw-semibold">Monto reservado *</label>
+                <input
+                  id="partidaMontoReservado"
+                  type="number"
+                  class="form-control"
+                  formControlName="montoReservado"
+                  step="0.01"
+                  min="0"
+                  [class.is-invalid]="form.controls.montoReservado.touched && form.controls.montoReservado.invalid"
+                />
+                <div class="invalid-feedback" *ngIf="form.controls.montoReservado.touched && form.controls.montoReservado.hasError('required')">
+                  El monto reservado es obligatorio.
+                </div>
+                <div class="invalid-feedback" *ngIf="form.controls.montoReservado.touched && form.controls.montoReservado.hasError('min')">
+                  El monto reservado no puede ser negativo.
+                </div>
+                <div class="invalid-feedback d-block" *ngIf="getServerError('montoReservado') as serverError">
+                  {{ serverError }}
+                </div>
+              </div>
+
+              <div class="col-12">
+                <label for="partidaNota" class="form-label">Nota</label>
+                <textarea
+                  id="partidaNota"
+                  rows="3"
+                  class="form-control"
+                  formControlName="nota"
+                  [class.is-invalid]="hasControlError('nota')"
+                ></textarea>
+                <div class="invalid-feedback" *ngIf="form.controls.nota.touched && form.controls.nota.hasError('maxlength')">
+                  La nota debe tener menos de 500 caracteres.
+                </div>
+                <div class="invalid-feedback d-block" *ngIf="getServerError('nota') as serverError">
+                  {{ serverError }}
+                </div>
+              </div>
             </div>
-            <div style="display: inline-flex; gap: 0.4rem;">
+
+            <div class="d-flex justify-content-end gap-2 mt-4">
+              <button type="button" class="btn btn-outline-secondary" (click)="promptCancelForm()" [disabled]="saving()">
+                Cancelar
+              </button>
+              <button type="submit" class="btn btn-primary" [disabled]="saving()">
+                {{ saving() ? 'Guardando...' : 'Guardar' }}
+              </button>
+            </div>
+          </form>
+        </div>
+      </div>
+    </section>
+
+    <ng-container *ngIf="!showForm() && !viewingPartida()">
+      <div class="card border-0 shadow-sm mt-4" *ngIf="!loading() && partidas().length > 0; else partidasEmptyState">
+        <div class="card-body p-0">
+          <div class="table-responsive">
+            <table class="table table-hover align-middle mb-0">
+              <thead class="table-light">
+                <tr>
+                  <th scope="col">Concepto</th>
+                  <th scope="col">Tipo</th>
+                  <th scope="col">Categoría</th>
+                  <th scope="col">Estado</th>
+                  <th scope="col" class="text-end">Monto reservado</th>
+                  <th scope="col" class="text-end">Monto aplicado</th>
+                  <th scope="col" class="text-end">Acciones</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr
+                  *ngFor="let partida of partidas(); trackBy: trackByPartidaId"
+                  [ngClass]="estadoRowClass(partida)"
+                >
+                  <th scope="row" class="fw-semibold">{{ partida.concepto }}</th>
+                  <td>
+                    <span class="tipo-pill" [ngClass]="partida.tipo === 'INGRESO' ? 'tipo-pill--ingreso' : 'tipo-pill--egreso'">
+                      {{ partida.tipo }}
+                    </span>
+                  </td>
+                  <td>{{ partida.categoriaNombre }}</td>
+                  <td>
+                    <span [ngClass]="'estado estado--' + partida.estado.toLowerCase()">{{ partida.estado }}</span>
+                  </td>
+                  <td class="text-end">{{ formatAccounting(partida.montoReservado) }}</td>
+                  <td class="text-end">{{ formatAccounting(partida.montoAplicado) }}</td>
+                  <td class="text-end">
+                    <button
+                      type="button"
+                      class="btn btn-outline-primary action-icon-button me-1"
+                      (click)="viewPartida(partida)"
+                      [disabled]="loading() || saving()"
+                      [attr.aria-label]="'Ver partida presupuestaria: ' + partida.concepto"
+                      [attr.title]="'Ver partida presupuestaria'"
+                    >
+                      <svg
+                        viewBox="0 0 24 24"
+                        fill="none"
+                        stroke="currentColor"
+                        stroke-width="1.5"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        aria-hidden="true"
+                      >
+                        <path d="M1 12s4-7 11-7 11 7 11 7-4 7-11 7-11-7-11-7z" />
+                        <circle cx="12" cy="12" r="3" />
+                      </svg>
+                      <span class="visually-hidden">Ver</span>
+                    </button>
+                    <button
+                      type="button"
+                      class="btn btn-outline-danger action-icon-button"
+                      (click)="promptDelete(partida)"
+                      [disabled]="loading() || saving()"
+                      [attr.aria-label]="'Eliminar partida presupuestaria: ' + partida.concepto"
+                      [attr.title]="'Eliminar partida presupuestaria'"
+                    >
+                      <svg
+                        viewBox="0 0 24 24"
+                        fill="none"
+                        stroke="currentColor"
+                        stroke-width="1.5"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        aria-hidden="true"
+                      >
+                        <polyline points="3 6 5 6 21 6" />
+                        <path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6" />
+                        <path d="M10 11v6" />
+                        <path d="M14 11v6" />
+                        <path d="M9 6V4a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v2" />
+                      </svg>
+                      <span class="visually-hidden">Eliminar</span>
+                    </button>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </div>
+
+      <ng-template #partidasEmptyState>
+        <div class="alert alert-secondary mt-4" *ngIf="!loading()">
+          {{
+            selectedPeriodoId() === null
+              ? 'Selecciona un periodo para ver las partidas presupuestarias.'
+              : 'No hay partidas presupuestarias registradas para el periodo seleccionado.'
+          }}
+        </div>
+      </ng-template>
+    </ng-container>
+
+    <section *ngIf="!showForm() && viewingPartida() as partida" class="partida-detalle mt-4">
+      <div class="card border-0 shadow-sm">
+        <div class="card-header d-flex flex-column flex-md-row justify-content-between align-items-start gap-3">
+          <div>
+            <h5 class="mb-1">{{ partida.concepto }}</h5>
+            <p class="text-muted mb-0">Actualizado {{ partida.actualizadoEn | date: 'short' }}</p>
+          </div>
+          <button type="button" class="btn btn-outline-secondary" (click)="closeViewPartida()">Volver al listado</button>
+        </div>
+        <div class="card-body">
+          <div class="row g-3">
+            <div class="col-12 col-md-6">
+              <div class="detalle-field">
+                <span class="detalle-field__label">Tipo</span>
+                <span class="detalle-field__value">
+                  <span class="tipo-pill" [ngClass]="partida.tipo === 'INGRESO' ? 'tipo-pill--ingreso' : 'tipo-pill--egreso'">
+                    {{ partida.tipo }}
+                  </span>
+                </span>
+              </div>
+            </div>
+            <div class="col-12 col-md-6">
+              <div class="detalle-field">
+                <span class="detalle-field__label">Categoría</span>
+                <span class="detalle-field__value">{{ partida.categoriaNombre }}</span>
+              </div>
+            </div>
+            <div class="col-12 col-md-6">
+              <div class="detalle-field">
+                <span class="detalle-field__label">Estado</span>
+                <span class="detalle-field__value">
+                  <span class="estado" [ngClass]="'estado--' + partida.estado.toLowerCase()">{{ partida.estado }}</span>
+                </span>
+              </div>
+            </div>
+            <div class="col-12 col-md-6">
+              <div class="detalle-field">
+                <span class="detalle-field__label">Periodo</span>
+                <span class="detalle-field__value">
+                  {{ partida.periodoNombre }}
+                  ({{ partida.periodoFechaInicio | date: 'longDate' }} - {{ partida.periodoFechaFin | date: 'longDate' }})
+                </span>
+              </div>
+            </div>
+            <div class="col-12 col-md-6">
+              <div class="detalle-field">
+                <span class="detalle-field__label">Monto reservado</span>
+                <div class="d-flex flex-wrap align-items-center justify-content-between gap-2">
+                  <span class="detalle-field__value">{{ formatAccounting(partida.montoReservado) }}</span>
+                  <button
+                    *ngIf="partida.estado === 'RESERVADO'"
+                    type="button"
+                    class="btn btn-primary btn-sm"
+                    (click)="startApplyMonto(partida)"
+                    [disabled]="applyingMonto() || applyingMontoSaving()"
+                  >
+                    Aplicar
+                  </button>
+                </div>
+              </div>
+            </div>
+            <div class="col-12 col-md-6">
+              <div
+                class="detalle-field"
+                [class.detalle-field--invalid]="applyingMonto() && montoAplicadoControl.touched && montoAplicadoControl.invalid"
+              >
+                <span class="detalle-field__label">Monto aplicado</span>
+                <ng-container *ngIf="applyingMonto(); else appliedReadonly">
+                  <div class="d-flex flex-column flex-sm-row align-items-stretch align-items-sm-center gap-2">
+                    <input
+                      type="number"
+                      min="0"
+                      step="0.01"
+                      class="form-control"
+                      [class.is-invalid]="montoAplicadoControl.touched && montoAplicadoControl.invalid"
+                      [formControl]="montoAplicadoControl"
+                    />
+                    <div class="d-flex gap-2">
+                      <button
+                        type="button"
+                        class="btn btn-primary"
+                        (click)="confirmApplyMonto(partida)"
+                        [disabled]="applyingMontoSaving()"
+                      >
+                        Aceptar
+                      </button>
+                      <button
+                        type="button"
+                        class="btn btn-outline-secondary"
+                        (click)="cancelApplyMonto()"
+                        [disabled]="applyingMontoSaving()"
+                      >
+                        Cancelar
+                      </button>
+                    </div>
+                  </div>
+                  <div class="invalid-feedback d-block" *ngIf="montoAplicadoControl.touched && montoAplicadoControl.hasError('required')">
+                    Ingresa el monto a aplicar.
+                  </div>
+                  <div class="invalid-feedback d-block" *ngIf="montoAplicadoControl.touched && montoAplicadoControl.hasError('min')">
+                    El monto aplicado no puede ser negativo.
+                  </div>
+                  <div class="invalid-feedback d-block" *ngIf="applyingMontoError() as applyError">{{ applyError }}</div>
+                </ng-container>
+                <ng-template #appliedReadonly>
+                  <span class="detalle-field__value">{{ formatAccounting(partida.montoAplicado ?? null) }}</span>
+                </ng-template>
+              </div>
+            </div>
+            <div class="col-12 col-md-6">
+              <div class="detalle-field">
+                <span class="detalle-field__label">Creado</span>
+                <span class="detalle-field__value">
+                  {{ partida.creadoEn | date: 'longDate' }} a las {{ partida.creadoEn | date: 'shortTime' }}
+                </span>
+              </div>
+            </div>
+            <div class="col-12 col-md-6">
+              <div class="detalle-field">
+                <span class="detalle-field__label">Actualizado</span>
+                <span class="detalle-field__value">
+                  {{ partida.actualizadoEn | date: 'longDate' }} a las {{ partida.actualizadoEn | date: 'shortTime' }}
+                </span>
+              </div>
+            </div>
+            <div class="col-12">
+              <div class="detalle-field">
+                <span class="detalle-field__label">Nota</span>
+                <span class="detalle-field__value">{{ partida.nota?.trim() || 'Sin nota registrada.' }}</span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <ng-container *ngIf="partidaPendingDelete() as partida">
+      <div
+        class="modal fade show d-block partida-delete-modal"
+        tabindex="-1"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="partidaDeleteModalLabel"
+      >
+        <div class="modal-dialog" role="document">
+          <div class="modal-content">
+            <div class="modal-header">
+              <h5 class="modal-title" id="partidaDeleteModalLabel">Eliminar partida presupuestaria</h5>
               <button
                 type="button"
-                class="primary-button"
-                style="padding: 0.35rem 0.75rem;"
-                (click)="confirmApplyMonto(partida)"
-                [disabled]="applyingMontoSaving()"
-                aria-label="Aceptar"
+                class="btn-close"
+                aria-label="Cerrar"
+                (click)="closeDeleteDialog()"
+                [disabled]="deleting()"
               >
-                <span aria-hidden="true">&#10003;</span>
+                <span aria-hidden="true"></span>
+              </button>
+            </div>
+            <div class="modal-body">
+              <p>¿Desea eliminar la partida presupuestaria "{{ partida.concepto }}"?</p>
+              <p class="mb-0 text-muted">Esta acción no se puede deshacer.</p>
+            </div>
+            <div class="modal-footer">
+              <button
+                type="button"
+                class="btn btn-danger"
+                (click)="confirmDeletePartida()"
+                [disabled]="deleting()"
+              >
+                {{ deleting() ? 'Eliminando...' : 'Eliminar' }}
               </button>
               <button
                 type="button"
-                class="danger-button"
-                style="padding: 0.35rem 0.75rem;"
-                (click)="cancelApplyMonto()"
-                [disabled]="applyingMontoSaving()"
-                aria-label="Cancelar"
+                class="btn btn-secondary"
+                (click)="closeDeleteDialog()"
+                [disabled]="deleting()"
               >
-                <span aria-hidden="true">&#10005;</span>
+                Cancelar
               </button>
             </div>
           </div>
-          <small *ngIf="montoAplicadoControl.touched && montoAplicadoControl.hasError('required')">
-            Ingresa el monto a aplicar.
-          </small>
-          <small *ngIf="montoAplicadoControl.touched && montoAplicadoControl.hasError('min')">
-            El monto aplicado no puede ser negativo.
-          </small>
-          <small *ngIf="applyingMontoError() as applyError">{{ applyError }}</small>
-        </ng-container>
-        <ng-template #appliedReadonly>
-          <p class="form-field__readonly">{{ formatAccounting(partida.montoAplicado ?? null) }}</p>
-        </ng-template>
+        </div>
       </div>
+      <div class="modal-backdrop fade show" style="display: block;"></div>
+    </ng-container>
 
-      <div class="form-field form-field--static">
-        <span>Creado</span>
-        <p class="form-field__readonly">
-          {{ partida.creadoEn | date: 'longDate' }}
-          a las {{ partida.creadoEn | date: 'shortTime' }}
-        </p>
-      </div>
-
-      <div class="form-field form-field--static">
-        <span>Actualizado</span>
-        <p class="form-field__readonly">
-          {{ partida.actualizadoEn | date: 'longDate' }}
-          a las {{ partida.actualizadoEn | date: 'shortTime' }}
-        </p>
-      </div>
-
-      <div class="form-field form-field--static form-field--full">
-        <span>Nota</span>
-        <p class="form-field__readonly">{{ partida.nota?.trim() || 'Sin nota registrada.' }}</p>
-      </div>
-    </div>
-
-    <div class="form-actions">
-      <button type="button" class="ghost-button" (click)="closeViewPartida()">
-        Volver
-      </button>
-    </div>
-  </section>
+    <app-confirm-dialog
+      [open]="cancelDialogOpen()"
+      [title]="cancelDialogTitle()"
+      [message]="cancelDialogMessage()"
+      confirmLabel="Sí, cancelar"
+      cancelLabel="Seguir creando"
+      (cancel)="closeCancelDialog()"
+      (confirm)="confirmCancelForm()"
+    ></app-confirm-dialog>
   </div>
 </section>

--- a/fnanz-app/src/app/features/partidas-presupuestarias/partidas-presupuestarias.component.html
+++ b/fnanz-app/src/app/features/partidas-presupuestarias/partidas-presupuestarias.component.html
@@ -9,7 +9,7 @@
     </div>
     <button
       type="button"
-      class="primary-button"
+      class="btn btn-primary"
       (click)="startCreate()"
       [disabled]="loading() || saving() || selectedPeriodoId() === null"
     >

--- a/fnanz-app/src/app/features/partidas-presupuestarias/partidas-presupuestarias.component.scss
+++ b/fnanz-app/src/app/features/partidas-presupuestarias/partidas-presupuestarias.component.scss
@@ -199,41 +199,41 @@
   justify-content: flex-end;
 }
 
-.data-table {
+.budget-table {
   border-collapse: collapse;
   width: 100%;
 }
 
-.data-table th,
-.data-table td {
+.budget-table th,
+.budget-table td {
   border-bottom: 1px solid #e5e7eb;
   padding: 0.75rem 1rem;
   text-align: left;
   vertical-align: top;
 }
 
-.data-table thead th {
+.budget-table thead th {
   color: #6b7280;
   font-size: 0.85rem;
   font-weight: 600;
   text-transform: uppercase;
 }
 
-.data-table tbody tr:hover {
+.budget-table tbody tr:hover {
   background-color: #f9fafb;
 }
 
-.data-table__actions {
+.budget-table__actions {
   text-align: right;
   white-space: nowrap;
 }
 
-.data-table__numeric {
+.budget-table__numeric {
   text-align: right;
   font-variant-numeric: tabular-nums;
 }
 
-.data-table__empty {
+.budget-table__empty {
   color: #6b7280;
   font-style: italic;
   padding: 2rem 1rem;
@@ -285,26 +285,27 @@
 }
 
 @media (max-width: 640px) {
-  .data-table thead {
+  .budget-table thead {
     display: none;
   }
 
-  .data-table tbody tr {
+  .budget-table tbody tr {
     display: grid;
     gap: 0.75rem;
     padding: 1rem 0;
   }
 
-  .data-table td {
+  .budget-table th,
+  .budget-table td {
     border: none;
     padding: 0;
   }
 
-  .data-table__numeric {
+  .budget-table__numeric {
     text-align: right;
   }
 
-  .data-table__actions {
+  .budget-table__actions {
     display: flex;
     gap: 0.5rem;
     justify-content: flex-end;

--- a/fnanz-app/src/app/features/partidas-presupuestarias/partidas-presupuestarias.component.scss
+++ b/fnanz-app/src/app/features/partidas-presupuestarias/partidas-presupuestarias.component.scss
@@ -1,246 +1,36 @@
-.partida-panel {
-  display: flex;
-  flex-direction: column;
-  gap: 1.5rem;
-}
-
 .partida-panel__header {
   align-items: flex-start;
   display: flex;
+  flex-wrap: wrap;
   gap: 1rem;
   justify-content: space-between;
-  flex-wrap: wrap;
+  margin-bottom: 1rem;
 }
 
-.partida-panel__subtitle {
-  color: #6b7280;
-  margin: 0.25rem 0 0;
-}
-
-.partida-panel__filters {
-  align-items: flex-end;
+.partida-form-wrapper {
   display: flex;
-  flex-wrap: wrap;
-  gap: 1rem;
-}
-
-.filter-field {
-  display: flex;
-  flex-direction: column;
-  gap: 0.35rem;
-}
-
-.filter-field span {
-  font-weight: 600;
-}
-
-.filter-field select {
-  border: 1px solid #d1d5db;
-  border-radius: 0.65rem;
-  font: inherit;
-  padding: 0.6rem 0.75rem;
-  min-width: 200px;
-}
-
-.filter-checkbox {
-  align-items: center;
-  display: inline-flex;
-  gap: 0.5rem;
-  font-weight: 500;
-}
-
-.filter-checkbox input[type='checkbox'] {
-  accent-color: var(--fnanz-primary);
-  height: 1.1rem;
-  width: 1.1rem;
-}
-
-.primary-button,
-.ghost-button,
-.danger-button {
-  border: none;
-  border-radius: 0.75rem;
-  cursor: pointer;
-  font-weight: 600;
-  padding: 0.65rem 1.4rem;
-  transition: transform 0.15s ease, box-shadow 0.15s ease;
-}
-
-.primary-button {
-  background: linear-gradient(90deg, var(--fnanz-primary), var(--fnanz-secondary));
-  color: #fff;
-  box-shadow: 0 8px 18px rgba(0, 80, 179, 0.25);
-}
-
-.primary-button:disabled {
-  cursor: not-allowed;
-  opacity: 0.6;
-  box-shadow: none;
-}
-
-.ghost-button {
-  background: #f3f4f6;
-  color: var(--fnanz-primary);
-}
-
-.danger-button {
-  background: #fee2e2;
-  color: #b91c1c;
-}
-
-.ghost-button:hover:not(:disabled),
-.danger-button:hover:not(:disabled),
-.primary-button:hover:not(:disabled) {
-  transform: translateY(-1px);
-}
-
-.partida-panel__loading,
-.partida-panel__error,
-.partida-panel__warning,
-.partida-panel__empty {
-  background-color: #f9fafb;
-  border-radius: 0.75rem;
-  padding: 1rem;
-  margin: 0;
-}
-
-.partida-panel__error {
-  background-color: #fee2e2;
-  color: #991b1b;
-}
-
-.partida-panel__warning {
-  background-color: #fef9c3;
-  color: #854d0e;
-}
-
-.partida-form {
-  background-color: #f9fafb;
-  border-radius: 1rem;
-  padding: 1.5rem;
-}
-
-.partida-form h3 {
-  margin-top: 0;
-}
-
-.partida-form__grid {
-  display: grid;
-  gap: 1rem;
-  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-}
-
-.form-field {
-  display: flex;
-  flex-direction: column;
-  font-size: 0.95rem;
-  gap: 0.35rem;
-}
-
-.form-field span {
-  font-weight: 600;
-}
-
-.form-field--invalid span {
-  color: #b91c1c;
-}
-
-.form-field input,
-.form-field select,
-.form-field textarea {
-  border: 1px solid #d1d5db;
-  border-radius: 0.65rem;
-  font: inherit;
-  padding: 0.6rem 0.75rem;
-}
-
-.form-field--invalid input,
-.form-field--invalid select,
-.form-field--invalid textarea {
-  border-color: #ef4444;
-}
-
-.form-field textarea {
-  resize: vertical;
-}
-
-.form-field input.invalid {
-  border-color: #ef4444;
-}
-
-.form-field small {
-  color: #b91c1c;
-  font-size: 0.75rem;
-}
-
-.form-field--full {
-  grid-column: 1 / -1;
-}
-
-.form-field--static {
-  grid-column: 1 / -1;
-}
-
-.form-field__readonly {
-  background-color: #fff;
-  border: 1px dashed #d1d5db;
-  border-radius: 0.65rem;
-  color: #374151;
-  font-weight: 500;
-  margin: 0;
-  padding: 0.6rem 0.75rem;
-}
-
-.form-actions {
-  align-items: center;
-  display: flex;
-  gap: 1rem;
-  grid-column: 1 / -1;
-  justify-content: flex-end;
-}
-
-.budget-table {
-  border-collapse: collapse;
+  justify-content: flex-start;
   width: 100%;
 }
 
-.budget-table th,
-.budget-table td {
-  border-bottom: 1px solid #e5e7eb;
-  padding: 0.75rem 1rem;
-  text-align: left;
-  vertical-align: top;
+.partida-form-card {
+  width: 100%;
 }
 
-.budget-table thead th {
-  color: #6b7280;
-  font-size: 0.85rem;
-  font-weight: 600;
-  text-transform: uppercase;
+.partida-filters .form-select {
+  min-width: 16rem;
 }
 
-.budget-table tbody tr:hover {
-  background-color: #f9fafb;
+.partida-filters .form-check {
+  padding-left: 2.5rem;
 }
 
-.budget-table__actions {
-  text-align: right;
-  white-space: nowrap;
+.partida-filters .form-check-input {
+  cursor: pointer;
 }
 
-.budget-table__numeric {
-  text-align: right;
-  font-variant-numeric: tabular-nums;
-}
-
-.budget-table__empty {
-  color: #6b7280;
-  font-style: italic;
-  padding: 2rem 1rem;
-  text-align: center;
-}
-
-.partida-name {
+.partida-filters .form-check-label {
+  cursor: pointer;
   font-weight: 600;
 }
 
@@ -284,30 +74,67 @@
   color: #b91c1c;
 }
 
-@media (max-width: 640px) {
-  .budget-table thead {
-    display: none;
-  }
+.action-icon-button {
+  align-items: center;
+  border-radius: 999px;
+  display: inline-flex;
+  height: 2.5rem;
+  justify-content: center;
+  padding: 0;
+  width: 2.5rem;
+}
 
-  .budget-table tbody tr {
-    display: grid;
-    gap: 0.75rem;
-    padding: 1rem 0;
-  }
+.action-icon-button svg {
+  height: 1.25rem;
+  width: 1.25rem;
+}
 
-  .budget-table th,
-  .budget-table td {
-    border: none;
-    padding: 0;
-  }
+.partida-detalle .card-header {
+  background-color: #f8f9fa;
+}
 
-  .budget-table__numeric {
-    text-align: right;
-  }
+.detalle-field {
+  border: 1px solid #dee2e6;
+  border-radius: 0.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  height: 100%;
+  padding: 0.75rem 1rem;
+}
 
-  .budget-table__actions {
-    display: flex;
-    gap: 0.5rem;
-    justify-content: flex-end;
+.detalle-field__label {
+  color: #6c757d;
+  font-size: 0.85rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+}
+
+.detalle-field__value {
+  color: #212529;
+  font-weight: 500;
+}
+
+.detalle-field--invalid {
+  border-color: #dc3545;
+}
+
+.detalle-field--invalid .detalle-field__label {
+  color: #dc3545;
+}
+
+.partida-delete-modal {
+  background-color: rgba(33, 37, 41, 0.6);
+}
+
+.partida-delete-modal .modal-dialog {
+  margin-top: 10vh;
+}
+
+@media (max-width: 576px) {
+  .action-icon-button {
+    height: 2.25rem;
+    width: 2.25rem;
   }
 }

--- a/fnanz-app/src/app/features/partidas-presupuestarias/partidas-presupuestarias.component.ts
+++ b/fnanz-app/src/app/features/partidas-presupuestarias/partidas-presupuestarias.component.ts
@@ -108,6 +108,19 @@ export class PartidasPresupuestariasComponent implements OnInit {
 
   trackByPartidaId = (_: number, partida: PartidaPresupuestaria): number => partida.id;
 
+  estadoRowClass(partida: PartidaPresupuestaria): string {
+    switch (partida.estado) {
+      case 'APLICADO':
+        return 'table-success';
+      case 'RESERVADO':
+        return 'table-warning';
+      case 'CANCELADO':
+        return 'table-danger';
+      default:
+        return '';
+    }
+  }
+
   private loadCategorias(): void {
     this.categoriasLoading.set(true);
     this.categoriasError.set(null);

--- a/fnanz-app/src/app/features/partidas-presupuestarias/partidas-presupuestarias.component.ts
+++ b/fnanz-app/src/app/features/partidas-presupuestarias/partidas-presupuestarias.component.ts
@@ -92,13 +92,6 @@ export class PartidasPresupuestariasComponent implements OnInit {
       '¿Deseas cancelar la creación de la partida presupuestaria? Los cambios no guardados se perderán.'
   );
 
-  readonly deleteMessage = computed(() => {
-    const partida = this.partidaPendingDelete();
-    return partida
-      ? `¿Desea eliminar la partida presupuestaria "${partida.concepto}"?`
-      : '';
-  });
-
   ngOnInit(): void {
     this.restoreSelectedPeriodoId();
     this.loadCategorias();

--- a/fnanz-app/src/app/features/periodos-financieros/periodos-financieros.component.html
+++ b/fnanz-app/src/app/features/periodos-financieros/periodos-financieros.component.html
@@ -7,7 +7,7 @@
           Gestiona los periodos utilizados para organizar tus registros financieros.
         </p>
       </div>
-      <button type="button" class="primary-button" (click)="startCreate()" [disabled]="loading() || saving()">
+      <button type="button" class="btn btn-primary" (click)="startCreate()" [disabled]="loading() || saving()">
         Nuevo periodo
       </button>
     </header>

--- a/fnanz-app/src/app/features/periodos-financieros/periodos-financieros.component.html
+++ b/fnanz-app/src/app/features/periodos-financieros/periodos-financieros.component.html
@@ -1,6 +1,6 @@
 <section class="card periodo-panel shadow-sm border-0">
   <div class="card-body">
-    <header class="periodo-panel__header">
+    <div class="periodo-panel__header">
       <div>
         <h2 class="card-title mb-1">Periodos</h2>
         <p class="card-subtitle text-muted">
@@ -10,179 +10,279 @@
       <button type="button" class="btn btn-primary" (click)="startCreate()" [disabled]="loading() || saving()">
         Nuevo periodo
       </button>
-    </header>
-
-    <p *ngIf="loading()" class="periodo-panel__loading">Cargando información...</p>
-    <p *ngIf="error() && !loading()" class="periodo-panel__error">{{ error() }}</p>
-
-    <section *ngIf="showForm()" class="periodo-form">
-      <h3>{{ formTitle() }}</h3>
-      <form [formGroup]="form" (ngSubmit)="submitForm()" class="periodo-form__grid">
-      <label class="form-field" [class.form-field--invalid]="hasControlError('nombre')">
-        <span>Nombre *</span>
-        <input type="text" formControlName="nombre" />
-        <small *ngIf="form.controls.nombre.touched && form.controls.nombre.hasError('required')">
-          El nombre es obligatorio.
-        </small>
-        <small *ngIf="form.controls.nombre.touched && form.controls.nombre.hasError('maxlength')">
-          El nombre debe tener menos de 150 caracteres.
-        </small>
-        <small *ngIf="getServerError('nombre') as serverError">{{ serverError }}</small>
-      </label>
-
-      <label class="form-field" [class.form-field--invalid]="hasControlError('fechaInicio')">
-        <span>Fecha de inicio *</span>
-        <input type="date" formControlName="fechaInicio" />
-        <small *ngIf="form.controls.fechaInicio.touched && form.controls.fechaInicio.hasError('required')">
-          La fecha de inicio es obligatoria.
-        </small>
-        <small *ngIf="getServerError('fechaInicio') as serverError">{{ serverError }}</small>
-      </label>
-
-      <label class="form-field" [class.form-field--invalid]="hasControlError('fechaFin')">
-        <span>Fecha de fin *</span>
-        <input type="date" formControlName="fechaFin" />
-        <small *ngIf="form.controls.fechaFin.touched && form.controls.fechaFin.hasError('required')">
-          La fecha de fin es obligatoria.
-        </small>
-        <small *ngIf="form.controls.fechaFin.touched && form.controls.fechaFin.hasError('dateRange')">
-          La fecha de fin debe ser posterior o igual a la fecha de inicio.
-        </small>
-        <small *ngIf="getServerError('fechaFin') as serverError">{{ serverError }}</small>
-      </label>
-
-      <label class="form-field" [class.form-field--invalid]="hasControlError('tipo')">
-        <span>Tipo</span>
-        <input type="text" formControlName="tipo" placeholder="Ej: Mensual, Trimestral" />
-        <small *ngIf="getServerError('tipo') as serverError">{{ serverError }}</small>
-      </label>
-
-      <label class="form-field form-field--full" [class.form-field--invalid]="hasControlError('descripcion')">
-        <span>Descripción</span>
-        <textarea rows="3" formControlName="descripcion"></textarea>
-        <small *ngIf="getServerError('descripcion') as serverError">{{ serverError }}</small>
-      </label>
-
-      <label class="form-field form-field--inline" [class.form-field--invalid]="hasControlError('cerrado')">
-        <input type="checkbox" formControlName="cerrado" />
-        <span>Periodo cerrado</span>
-        <small *ngIf="getServerError('cerrado') as serverError">{{ serverError }}</small>
-      </label>
-
-      <div class="form-actions">
-        <button type="button" class="ghost-button" (click)="cancelForm()">Cancelar</button>
-        <button type="submit" class="primary-button" [disabled]="saving()">
-          {{ saving() ? 'Guardando...' : 'Guardar' }}
-        </button>
-      </div>
-    </form>
-  </section>
-
-    <div class="periodo-grid" *ngIf="!loading() && periodos().length > 0; else emptyState">
-      <table class="data-table">
-        <thead>
-          <tr>
-            <th>Nombre</th>
-            <th>Rango</th>
-            <th>Tipo</th>
-            <th>Estado</th>
-            <th>Descripción</th>
-            <th class="data-table__actions">Acciones</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr *ngFor="let periodo of periodos(); trackBy: trackByPeriodoId">
-            <td>
-              <div class="periodo-name">{{ periodo.nombre }}</div>
-              <small class="periodo-meta">Actualizado {{ periodo.actualizadoEn | date: 'short' }}</small>
-            </td>
-            <td>
-              <div>{{ periodo.fechaInicio | date: 'mediumDate' }} – {{ periodo.fechaFin | date: 'mediumDate' }}</div>
-            </td>
-            <td>{{ periodo.tipo || '—' }}</td>
-            <td>
-              <span [ngClass]="periodo.cerrado ? 'estado estado--cerrado' : 'estado estado--abierto'">
-                {{ periodo.cerrado ? 'Cerrado' : 'Abierto' }}
-              </span>
-            </td>
-            <td>{{ periodo.descripcion || 'Sin descripción' }}</td>
-            <td class="data-table__actions">
-              <button
-                type="button"
-                class="ghost-button"
-                [routerLink]="['/periodos', periodo.id, 'reservas-resumen']"
-                [state]="{ periodoNombre: periodo.nombre }"
-              >
-                Ver resumen
-              </button>
-              <button
-                type="button"
-                class="ghost-button icon-button"
-                (click)="startEdit(periodo)"
-                [disabled]="loading() || saving()"
-                [attr.aria-label]="'Editar periodo: ' + periodo.nombre"
-                [attr.title]="'Editar periodo'"
-              >
-                <svg
-                  viewBox="0 0 24 24"
-                  fill="none"
-                  stroke="currentColor"
-                  stroke-width="1.5"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  aria-hidden="true"
-                >
-                  <path d="M12 20h9" />
-                  <path d="M16.5 3.5a2.121 2.121 0 1 1 3 3L7 19l-4 1 1-4L16.5 3.5z" />
-                </svg>
-              </button>
-              <button
-                type="button"
-                class="danger-button icon-button"
-                (click)="promptDelete(periodo)"
-                [disabled]="loading() || saving()"
-                [attr.aria-label]="'Eliminar periodo: ' + periodo.nombre"
-                [attr.title]="'Eliminar periodo'"
-              >
-                <svg
-                  viewBox="0 0 24 24"
-                  fill="none"
-                  stroke="currentColor"
-                  stroke-width="1.5"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  aria-hidden="true"
-                >
-                  <polyline points="3 6 5 6 21 6" />
-                  <path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6" />
-                  <path d="M10 11v6" />
-                  <path d="M14 11v6" />
-                  <path d="M9 6V4a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v2" />
-                </svg>
-              </button>
-            </td>
-          </tr>
-        </tbody>
-      </table>
     </div>
 
-    <ng-template #emptyState>
-      <p class="periodo-panel__empty" *ngIf="!loading()">
-        No hay periodos registrados todavía. Crea el primero para comenzar.
-      </p>
-    </ng-template>
+    <div *ngIf="loading()" class="alert alert-info mt-3 mb-0" role="status">Cargando información...</div>
+    <div *ngIf="error() && !loading()" class="alert alert-danger mt-3 mb-0" role="alert">{{ error() }}</div>
 
-    <app-confirm-dialog
-      [open]="periodoPendingDelete() !== null"
-      title="Eliminar periodo"
-      [message]="deleteMessage()"
-      confirmLabel="Eliminar"
-      cancelLabel="Cancelar"
-      busyLabel="Eliminando..."
-      [busy]="deleting()"
-      [confirmDestructive]="true"
-      (cancel)="closeDeleteDialog()"
-      (confirm)="confirmDeletePeriodo()"
-    ></app-confirm-dialog>
+    <section *ngIf="showForm()" class="periodo-form-wrapper mt-4">
+      <div class="card border-dark periodo-form-card">
+        <div class="card-header">
+          <h5 class="mb-0">{{ formTitle() }}</h5>
+        </div>
+        <div class="card-body">
+          <form [formGroup]="form" (ngSubmit)="submitForm()" novalidate>
+            <div class="mb-3">
+              <label for="periodoNombre" class="form-label fw-semibold">Nombre *</label>
+              <input
+                id="periodoNombre"
+                type="text"
+                formControlName="nombre"
+                class="form-control"
+                [class.is-invalid]="hasControlError('nombre')"
+              />
+              <div class="invalid-feedback" *ngIf="form.controls.nombre.touched && form.controls.nombre.hasError('required')">
+                El nombre es obligatorio.
+              </div>
+              <div class="invalid-feedback" *ngIf="form.controls.nombre.touched && form.controls.nombre.hasError('maxlength')">
+                El nombre debe tener menos de 150 caracteres.
+              </div>
+              <div class="invalid-feedback" *ngIf="getServerError('nombre') as serverError">{{ serverError }}</div>
+            </div>
+
+            <div class="row g-3">
+              <div class="col-md-6">
+                <label for="periodoFechaInicio" class="form-label fw-semibold">Fecha de inicio *</label>
+                <input
+                  id="periodoFechaInicio"
+                  type="date"
+                  formControlName="fechaInicio"
+                  class="form-control"
+                  [class.is-invalid]="hasControlError('fechaInicio')"
+                />
+                <div class="invalid-feedback" *ngIf="form.controls.fechaInicio.touched && form.controls.fechaInicio.hasError('required')">
+                  La fecha de inicio es obligatoria.
+                </div>
+                <div class="invalid-feedback" *ngIf="getServerError('fechaInicio') as serverError">{{ serverError }}</div>
+              </div>
+              <div class="col-md-6">
+                <label for="periodoFechaFin" class="form-label fw-semibold">Fecha de fin *</label>
+                <input
+                  id="periodoFechaFin"
+                  type="date"
+                  formControlName="fechaFin"
+                  class="form-control"
+                  [class.is-invalid]="
+                    hasControlError('fechaFin') ||
+                    (form.controls.fechaFin.touched && form.controls.fechaFin.hasError('dateRange'))
+                  "
+                />
+                <div class="invalid-feedback" *ngIf="form.controls.fechaFin.touched && form.controls.fechaFin.hasError('required')">
+                  La fecha de fin es obligatoria.
+                </div>
+                <div class="invalid-feedback" *ngIf="form.controls.fechaFin.touched && form.controls.fechaFin.hasError('dateRange')">
+                  La fecha de fin debe ser posterior o igual a la fecha de inicio.
+                </div>
+                <div class="invalid-feedback" *ngIf="getServerError('fechaFin') as serverError">{{ serverError }}</div>
+              </div>
+            </div>
+
+            <div class="mt-3">
+              <label for="periodoTipo" class="form-label fw-semibold">Tipo</label>
+              <input
+                id="periodoTipo"
+                type="text"
+                formControlName="tipo"
+                class="form-control"
+                placeholder="Ej: Mensual, Trimestral"
+                [ngClass]="{ 'is-invalid': getServerError('tipo') }"
+              />
+              <div class="invalid-feedback" *ngIf="getServerError('tipo') as serverError">{{ serverError }}</div>
+            </div>
+
+            <div class="mb-3">
+              <label for="periodoDescripcion" class="form-label fw-semibold">Descripción</label>
+              <textarea
+                id="periodoDescripcion"
+                rows="3"
+                formControlName="descripcion"
+                class="form-control"
+                [ngClass]="{ 'is-invalid': getServerError('descripcion') }"
+              ></textarea>
+              <div class="invalid-feedback" *ngIf="getServerError('descripcion') as serverError">{{ serverError }}</div>
+            </div>
+
+            <div class="mt-3">
+              <div class="form-check form-switch">
+                <input
+                  class="form-check-input"
+                  type="checkbox"
+                  role="switch"
+                  id="periodoCerrado"
+                  formControlName="cerrado"
+                />
+                <label class="form-check-label" for="periodoCerrado">Periodo cerrado</label>
+              </div>
+              <div class="form-text">{{ form.controls.cerrado.value ? 'El periodo estará cerrado' : 'El periodo estará abierto' }}</div>
+              <div class="invalid-feedback d-block" *ngIf="getServerError('cerrado') as serverError">{{ serverError }}</div>
+            </div>
+
+            <div class="d-flex justify-content-end gap-2 mt-4">
+              <button type="button" class="btn btn-outline-secondary" (click)="cancelForm()">Cancelar</button>
+              <button type="submit" class="btn btn-primary" [disabled]="saving()">
+                {{ saving() ? 'Guardando...' : 'Guardar' }}
+              </button>
+            </div>
+          </form>
+        </div>
+      </div>
+    </section>
+
+    <ng-container *ngIf="!showForm()">
+      <div class="periodo-grid" *ngIf="!loading() && periodos().length > 0; else emptyState">
+        <div class="card border-0 shadow-sm mt-4">
+          <div class="card-body p-0">
+            <div class="table-responsive">
+              <table class="table table-hover align-middle mb-0">
+                <thead class="table-light">
+                  <tr>
+                    <th scope="col">Nombre</th>
+                    <th scope="col">Rango</th>
+                    <th scope="col">Tipo</th>
+                    <th scope="col">Estado</th>
+                    <th scope="col">Descripción</th>
+                    <th scope="col" class="text-end">Acciones</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr *ngFor="let periodo of periodos(); trackBy: trackByPeriodoId">
+                    <td class="fw-semibold">
+                      {{ periodo.nombre }}
+                      <div class="text-muted small" *ngIf="periodo.actualizadoEn">
+                        Actualizado {{ periodo.actualizadoEn | date: 'short' }}
+                      </div>
+                    </td>
+                    <td>
+                      {{ periodo.fechaInicio | date: 'mediumDate' }} – {{ periodo.fechaFin | date: 'mediumDate' }}
+                    </td>
+                    <td>{{ periodo.tipo || '—' }}</td>
+                    <td>
+                      <span [ngClass]="periodo.cerrado ? 'estado estado--cerrado' : 'estado estado--abierto'">
+                        {{ periodo.cerrado ? 'Cerrado' : 'Abierto' }}
+                      </span>
+                    </td>
+                    <td>{{ periodo.descripcion || 'Sin descripción' }}</td>
+                    <td class="text-end">
+                      <a
+                        class="btn btn-outline-secondary btn-sm me-2"
+                        [routerLink]="['/periodos', periodo.id, 'reservas-resumen']"
+                        [state]="{ periodoNombre: periodo.nombre }"
+                      >
+                        Ver resumen
+                      </a>
+                      <button
+                        type="button"
+                        class="btn btn-outline-primary action-icon-button me-1"
+                        (click)="startEdit(periodo)"
+                        [disabled]="loading() || saving()"
+                        [attr.aria-label]="'Editar periodo: ' + periodo.nombre"
+                        [attr.title]="'Editar periodo'"
+                      >
+                        <svg
+                          viewBox="0 0 24 24"
+                          fill="none"
+                          stroke="currentColor"
+                          stroke-width="1.5"
+                          stroke-linecap="round"
+                          stroke-linejoin="round"
+                          aria-hidden="true"
+                        >
+                          <path d="M12 20h9" />
+                          <path
+                            d="M16.5 3.5a2.121 2.121 0 0 1 3 3L7 19l-4 1 1-4 12.5-12.5z"
+                          />
+                        </svg>
+                        <span class="visually-hidden">Editar</span>
+                      </button>
+                      <button
+                        type="button"
+                        class="btn btn-outline-danger action-icon-button"
+                        (click)="promptDelete(periodo)"
+                        [disabled]="loading() || saving()"
+                        [attr.aria-label]="'Eliminar periodo: ' + periodo.nombre"
+                        [attr.title]="'Eliminar periodo'"
+                      >
+                        <svg
+                          viewBox="0 0 24 24"
+                          fill="none"
+                          stroke="currentColor"
+                          stroke-width="1.5"
+                          stroke-linecap="round"
+                          stroke-linejoin="round"
+                          aria-hidden="true"
+                        >
+                          <polyline points="3 6 5 6 21 6" />
+                          <path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6" />
+                          <path d="M10 11v6" />
+                          <path d="M14 11v6" />
+                          <path d="M9 6V4a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v2" />
+                        </svg>
+                        <span class="visually-hidden">Eliminar</span>
+                      </button>
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <ng-template #emptyState>
+        <div class="alert alert-secondary mt-4" *ngIf="!loading()">
+          No hay periodos registrados todavía. Crea el primero para comenzar.
+        </div>
+      </ng-template>
+    </ng-container>
+
+    <ng-container *ngIf="periodoPendingDelete() as periodo">
+      <div
+        class="modal fade show d-block periodo-delete-modal"
+        tabindex="-1"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="periodoDeleteModalLabel"
+      >
+        <div class="modal-dialog" role="document">
+          <div class="modal-content">
+            <div class="modal-header">
+              <h5 class="modal-title" id="periodoDeleteModalLabel">Eliminar periodo</h5>
+              <button
+                type="button"
+                class="btn-close"
+                aria-label="Cerrar"
+                (click)="closeDeleteDialog()"
+                [disabled]="deleting()"
+              >
+                <span aria-hidden="true"></span>
+              </button>
+            </div>
+            <div class="modal-body">
+              <p>¿Desea eliminar el periodo "{{ periodo.nombre }}"?</p>
+              <p class="mb-0 text-muted">Esta acción no se puede deshacer.</p>
+            </div>
+            <div class="modal-footer">
+              <button
+                type="button"
+                class="btn btn-danger"
+                (click)="confirmDeletePeriodo()"
+                [disabled]="deleting()"
+              >
+                {{ deleting() ? 'Eliminando...' : 'Eliminar' }}
+              </button>
+              <button
+                type="button"
+                class="btn btn-secondary"
+                (click)="closeDeleteDialog()"
+                [disabled]="deleting()"
+              >
+                Cancelar
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div class="modal-backdrop fade show" style="display: block;"></div>
+    </ng-container>
   </div>
 </section>

--- a/fnanz-app/src/app/features/periodos-financieros/periodos-financieros.component.scss
+++ b/fnanz-app/src/app/features/periodos-financieros/periodos-financieros.component.scss
@@ -1,186 +1,24 @@
-.periodo-panel {
-  display: flex;
-  flex-direction: column;
-  gap: 1.5rem;
-}
-
 .periodo-panel__header {
   align-items: flex-start;
   display: flex;
+  flex-wrap: wrap;
   gap: 1rem;
   justify-content: space-between;
-  flex-wrap: wrap;
+  margin-bottom: 1rem;
 }
 
-.periodo-panel__subtitle {
-  color: #6b7280;
-  margin: 0.25rem 0 0;
-}
-
-.primary-button,
-.ghost-button,
-.danger-button {
-  border: none;
-  border-radius: 0.75rem;
-  cursor: pointer;
-  font-weight: 600;
-  padding: 0.65rem 1.4rem;
-  transition: transform 0.15s ease, box-shadow 0.15s ease;
-}
-
-.primary-button {
-  background: linear-gradient(90deg, var(--fnanz-primary), var(--fnanz-secondary));
-  color: #fff;
-  box-shadow: 0 8px 18px rgba(0, 80, 179, 0.25);
-}
-
-.primary-button:disabled {
-  cursor: not-allowed;
-  opacity: 0.6;
-  box-shadow: none;
-}
-
-.ghost-button {
-  background: #f3f4f6;
-  color: var(--fnanz-primary);
-}
-
-.danger-button {
-  background: #fee2e2;
-  color: #b91c1c;
-}
-
-.ghost-button:hover:not(:disabled),
-.danger-button:hover:not(:disabled),
-.primary-button:hover:not(:disabled) {
-  transform: translateY(-1px);
-}
-
-.periodo-panel__loading,
-.periodo-panel__error,
-.periodo-panel__empty {
-  background-color: #f9fafb;
-  border-radius: 0.75rem;
-  padding: 1rem;
-  margin: 0;
-}
-
-.periodo-panel__error {
-  background-color: #fee2e2;
-  color: #991b1b;
-}
-
-.periodo-form {
-  background-color: #f9fafb;
-  border-radius: 1rem;
-  padding: 1.5rem;
-}
-
-.periodo-form h3 {
-  margin-top: 0;
-}
-
-.periodo-form__grid {
-  display: grid;
-  gap: 1rem;
-  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-}
-
-.form-field {
+.periodo-form-wrapper {
   display: flex;
-  flex-direction: column;
-  font-size: 0.95rem;
-  gap: 0.35rem;
-}
-
-.form-field span {
-  font-weight: 600;
-}
-
-.form-field--invalid span {
-  color: #b91c1c;
-}
-
-.form-field input,
-.form-field select,
-.form-field textarea {
-  border: 1px solid #d1d5db;
-  border-radius: 0.65rem;
-  font: inherit;
-  padding: 0.6rem 0.75rem;
-}
-
-.form-field--invalid input,
-.form-field--invalid select,
-.form-field--invalid textarea {
-  border-color: #ef4444;
-}
-
-.form-field textarea {
-  resize: vertical;
-}
-
-.form-field small {
-  color: #b91c1c;
-  font-size: 0.75rem;
-}
-
-.form-field--inline {
-  align-items: center;
-  flex-direction: row;
-}
-
-.form-field--inline input[type='checkbox'] {
-  margin-right: 0.5rem;
-}
-
-.form-field--full {
-  grid-column: 1 / -1;
-}
-
-.form-actions {
-  align-items: center;
-  display: flex;
-  gap: 1rem;
-  grid-column: 1 / -1;
-  justify-content: flex-end;
-}
-
-.data-table {
-  border-collapse: collapse;
+  justify-content: flex-start;
   width: 100%;
 }
 
-.data-table th,
-.data-table td {
-  border-bottom: 1px solid #e5e7eb;
-  padding: 0.75rem 1rem;
-  text-align: left;
-  vertical-align: top;
+.periodo-form-card {
+  width: 100%;
 }
 
-.data-table thead th {
-  color: #6b7280;
-  font-size: 0.85rem;
-  font-weight: 600;
-  text-transform: uppercase;
-}
-
-.data-table tbody tr:hover {
-  background-color: #f9fafb;
-}
-
-.data-table__actions {
-  text-align: right;
-  white-space: nowrap;
-}
-
-.periodo-name {
-  font-weight: 600;
-}
-
-.periodo-meta {
-  color: #6b7280;
+.periodo-grid .table .small {
+  font-size: 0.75rem;
 }
 
 .estado {
@@ -198,5 +36,28 @@
 
 .estado--cerrado {
   background-color: #fee2e2;
-  color: #991b1b;
+  color: #b91c1c;
+}
+
+.action-icon-button {
+  align-items: center;
+  border-radius: 999px;
+  display: inline-flex;
+  height: 2.5rem;
+  justify-content: center;
+  padding: 0;
+  width: 2.5rem;
+}
+
+.action-icon-button svg {
+  height: 1.25rem;
+  width: 1.25rem;
+}
+
+.periodo-delete-modal {
+  background-color: rgba(33, 37, 41, 0.6);
+}
+
+.periodo-delete-modal .modal-dialog {
+  margin-top: 10vh;
 }

--- a/fnanz-app/src/app/features/periodos-financieros/periodos-financieros.component.ts
+++ b/fnanz-app/src/app/features/periodos-financieros/periodos-financieros.component.ts
@@ -8,13 +8,11 @@ import {
   PeriodoFinancieroCreate
 } from '../../shared/models/periodo-financiero.model';
 import { PeriodoFinancieroService } from '../../core/services/periodo-financiero.service';
-import { ConfirmDialogComponent } from '../../shared/components/confirm-dialog/confirm-dialog.component';
 
 @Component({
   selector: 'app-periodos-financieros',
   standalone: true,
   imports: [
-    ConfirmDialogComponent,
     DatePipe,
     NgClass,
     NgFor,
@@ -78,11 +76,6 @@ export class PeriodosFinancierosComponent implements OnInit {
       ? `Editar periodo: ${this.selectedPeriodo()!.nombre}`
       : 'Nuevo periodo'
   );
-
-  readonly deleteMessage = computed(() => {
-    const periodo = this.periodoPendingDelete();
-    return periodo ? `¿Desea eliminar el periodo "${periodo.nombre}"?` : '';
-  });
 
   ngOnInit(): void {
     this.form.controls.fechaFin.addValidators(this.fechaFinValidator);


### PR DESCRIPTION
## Summary
- update the presupuestos grid markup to use the theme's table structure and semantic headers
- apply contextual row classes based on estado to mirror the theme examples
- rename the supporting styles to match the new table classes while preserving responsive behaviour

## Testing
- npm run lint *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68ebcffe7e00832f811946c89b2b9a08